### PR TITLE
price-model v12: platform encoding + LGB retune + sensitivity tooling

### DIFF
--- a/.github/workflows/sensitivity.yml
+++ b/.github/workflows/sensitivity.yml
@@ -1,0 +1,46 @@
+name: Sensitivity Monitor
+
+# Weekly evidence-check of the price-model's tunable constants. Re-sweeps the
+# watchlist on the freshest release data; the job FAILS (red + notification)
+# only if a constant flipped noise→REAL — i.e. data drifted enough that it's
+# worth a human look (then re-sweep with --const for detail, or run
+# scripts/tune_lgb_params.py). See scripts/sweep_constant.py. Decoupled from
+# the frequent scrape on purpose: constants drift over weeks, not per-scrape,
+# and a ~10-min scan has no business running 5×/day.
+on:
+  schedule:
+    - cron: "0 6 * * 0"   # Sundays 06:00 UTC
+  workflow_dispatch:
+
+# Own group so it never cancels (or is cancelled by) a scrape; the single
+# self-hosted runner serialises them anyway.
+concurrency:
+  group: olx-sensitivity
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    runs-on: [self-hosted, olx-scraper]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python venv
+        run: |
+          /opt/homebrew/bin/python3.14 -m venv .venv 2>/dev/null || true
+          .venv/bin/pip install -q -e .
+
+      - name: Sweep watchlist constants (time-aware sensitivity)
+        # Exits 1 if any constant flipped noise→REAL → job fails → GitHub pings.
+        run: |
+          set -o pipefail
+          PYTHONWARNINGS=ignore .venv/bin/python -m scripts.sweep_constant --all \
+            | tee sensitivity_report.txt
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sensitivity-report
+          path: sensitivity_report.txt
+          retention-days: 90

--- a/scripts/sweep_constant.py
+++ b/scripts/sweep_constant.py
@@ -1,0 +1,278 @@
+"""Sensitivity harness — sweep any hardcoded price-model constant and measure
+its effect on out-of-fold quality, under BOTH random-KFold and a TIME-AWARE
+forward split, with bootstrap CIs. Turns "why is this number 20?" debates into
+a 5-minute evidence check.
+
+Why it exists: most of the model's magic numbers (credibility K, fold guards,
+category mins, …) live in the noise floor — sweeping proves it before anyone
+hand-tunes. And random KFold flatters (it lets the model peek at contemporaneous
+sales); the time-aware split is the honest read. This tool always shows both.
+
+Data: pulls sold listings from the `latest-data` GitHub Release snapshot
+(see the release-db skill — no local DB on the dev Mac). It reuses the prod
+feature pipeline (price_model._prepare_X / _model_for_quantile /
+_fit_platform_encoding) so a swept constant flows through exactly as in prod.
+It is a RELATIVE-delta tool: absolute MAPE differs from prod CV (no turnover
+features, fixed n_estimators), but ΔMAPE vs the current value is what matters.
+
+Usage:
+  python -m scripts.sweep_constant --const _PLAT_CRED_K --values 0.3,5,20,40,80
+  python -m scripts.sweep_constant --const _LGB_PARAMS.num_leaves --values 15,31,63
+  python -m scripts.sweep_constant --const _MONOTONE_BY_FEATURE.enc_plat --values 0,1
+  python -m scripts.sweep_constant --const _LGB_PARAMS.learning_rate --values 0.03,0.05,0.1 --full
+Flags:
+  --full     also fit low/high quantiles -> report pinball + [P10,P90] coverage
+  --data P   use a local listings.parquet instead of downloading the release
+  --segments d,p,h,e,phev  restrict reported fuel segments (default: all)
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import KFold, TimeSeriesSplit
+
+from src.analytics import price_model as pm
+
+_CACHE = Path("/tmp/olx-release/listings.parquet")
+_N_EST = 400          # fixed (no early stopping) so every swept value is comparable
+_N_BOOT = 2000
+_RNG = np.random.RandomState(42)
+
+
+def _norm_fuel(s: str) -> str:
+    s = str(s).lower()
+    if "plug" in s:
+        return "PHEV"
+    if "íbrid" in s or "ibrid" in s:
+        return "Hybrid"
+    if "elétr" in s or "eléctr" in s or "electr" in s:
+        return "EV"
+    if "diesel" in s or "asóleo" in s or "asoleo" in s:
+        return "Diesel"
+    if "asolina" in s:
+        return "Petrol"
+    return "Other"
+
+
+def load_sold(data_path: str | None) -> pd.DataFrame:
+    """Sold listings from the release snapshot (the only labelled price signal)."""
+    path = Path(data_path) if data_path else _CACHE
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        repo = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        print(f"Downloading listings.parquet from {repo}:latest-data …", file=sys.stderr)
+        subprocess.run(
+            ["gh", "release", "download", "latest-data", "--repo", repo,
+             "--pattern", "listings.parquet", "--dir", str(path.parent), "--clobber"],
+            check=True,
+        )
+    df = pd.read_parquet(path)
+    df = df[df["deactivation_reason"].astype(str).str.lower() == "sold"].copy()
+    df = df.dropna(subset=["price_eur", "year", "mileage_km"])
+    df["age"] = (2026 - df["year"]).clip(lower=1)
+    df = df[
+        df["price_eur"].between(800, 150000)
+        & df["mileage_km"].between(1000, 500000)
+        & (df["age"] < 25)
+    ]
+    df["fuel_norm"] = df["fuel_type"].map(_norm_fuel)
+    df["dt"] = pd.to_datetime(df["deactivated_at"], errors="coerce")
+    df = df.dropna(subset=["dt"]).reset_index(drop=True)
+    return df
+
+
+def _folds(df: pd.DataFrame, mode: str):
+    if mode == "random":
+        return list(KFold(5, shuffle=True, random_state=42).split(df))
+    order = np.argsort(df["dt"].values, kind="stable")
+    return [(order[tr], order[te]) for tr, te in TimeSeriesSplit(n_splits=4).split(order)]
+
+
+def evaluate(df: pd.DataFrame, folds, full: bool) -> dict:
+    """OOF predictions reusing prod feature prep + model construction so the
+    patched constant takes effect. Platform encoding is leakage-safe per fold."""
+    y = np.log1p(np.maximum(df["price_eur"].values.astype(float), 0))
+    n = len(df)
+    quants = pm._QUANTILES if full else {"median": 0.5}
+    oof = {q: np.full(n, np.nan) for q in quants}
+    tested = np.zeros(n, bool)
+    cat_idx = [pm._ALL_FEATURES.index(c) for c in pm.CATEGORICAL_FEATURES]
+    for tr, te in folds:
+        tr_df, te_df = df.iloc[tr], df.iloc[te]
+        plat = pm._fit_platform_encoding(tr_df, y[tr])      # uses pm._PLAT_CRED_K
+        x_tr, cmaps = pm._prepare_X(tr_df, plat_enc=plat)
+        x_te, _ = pm._prepare_X(te_df, cmaps, plat_enc=plat)
+        for name, alpha in quants.items():
+            model = pm._model_for_quantile(name, alpha, _N_EST)   # uses pm._LGB_PARAMS + monotone
+            model.fit(x_tr, y[tr], categorical_feature=cat_idx)
+            oof[name][te] = model.predict(x_te)
+        tested[te] = True
+    return {"oof": oof, "tested": tested, "y": y, "price": df["price_eur"].values.astype(float)}
+
+
+def _mape(res, mask):
+    m = mask & res["tested"]            # TimeSeriesSplit never predicts the first block
+    p = np.expm1(res["oof"]["median"]); pr = res["price"]
+    return float(np.mean(np.abs(p[m] - pr[m]) / pr[m]) * 100)
+
+
+def _coverage(res, mask):
+    m = mask & res["tested"]
+    lo = np.expm1(res["oof"]["low"]); hi = np.expm1(res["oof"]["high"]); pr = res["price"]
+    return float(np.mean((pr[m] >= lo[m]) & (pr[m] <= hi[m])) * 100)
+
+
+def _set_const(path: str, raw: str):
+    """Patch pm.<const> (scalar) or pm.<DICT>.<key>; return (restore_fn, parsed)."""
+    val: object
+    for cast in (int, float):
+        try:
+            val = cast(raw); break
+        except ValueError:
+            val = raw
+    if "." in path:
+        name, key = path.split(".", 1)
+        d = getattr(pm, name)
+        old = d.get(key, KeyError)
+        d[key] = val
+        def restore():
+            if old is KeyError:
+                d.pop(key, None)
+            else:
+                d[key] = old
+        return restore, val
+    old = getattr(pm, path)
+    setattr(pm, path, val)
+    return (lambda: setattr(pm, path, old)), val
+
+
+def _current(path: str):
+    if "." in path:
+        name, key = path.split(".", 1)
+        return getattr(pm, name).get(key)
+    return getattr(pm, path)
+
+
+# Constants worth periodically re-checking as data drifts. The LGB params are
+# the ones with real effect size (bucket C); the rest are guards we expect to
+# stay noise — the point is to be ALERTED if any flips noise→REAL.
+_WATCHLIST = [
+    ("_PLAT_CRED_K", "5,20,80"),
+    ("_LGB_PARAMS.num_leaves", "15,31,63"),
+    ("_LGB_PARAMS.max_depth", "4,6,8"),
+    ("_LGB_PARAMS.learning_rate", "0.03,0.05,0.1"),
+    ("_LGB_PARAMS.min_child_samples", "5,10,20"),
+    ("_LGB_PARAMS.reg_lambda", "0.5,1.5,5"),
+    ("_MONOTONE_BY_FEATURE.enc_plat", "0,1"),
+]
+
+
+def _verdict(lo: float, hi: float) -> str:
+    return "REAL ✓" if hi < 0 else "REAL ✗(worse)" if lo > 0 else "noise (CI∋0)"
+
+
+def sweep_one(df, folds, segs, mask_for, const, values, full, compact) -> bool:
+    """Sweep one constant; print results. Returns True if any value is a real
+    (CI-clears-0) IMPROVEMENT over the current value — i.e. worth a human look."""
+    baseline_val = _current(const)
+    base = {m: evaluate(df, folds[m], full) for m in ("random", "time")}
+    base_mape = {m: {s: _mape(base[m], mask_for(s)) for s in segs} for m in ("random", "time")}
+    cache, rows = {}, []
+    for raw in values:
+        restore, _ = _set_const(const, raw)
+        try:
+            cache[raw] = {m: evaluate(df, folds[m], full) for m in ("random", "time")}
+        finally:
+            restore()
+        res = cache[raw]
+        d_rnd = _mape(res["random"], mask_for("all")) - base_mape["random"]["all"]
+        d_time = _mape(res["time"], mask_for("all")) - base_mape["time"]["all"]
+        mk = np.where(res["time"]["tested"])[0]
+        b_oof, t_oof, pr = base["time"]["oof"]["median"], res["time"]["oof"]["median"], res["time"]["price"]
+        boot = []
+        for _ in range(_N_BOOT):
+            s = _RNG.choice(mk, len(mk), replace=True)
+            e_b = np.abs(np.expm1(b_oof[s]) - pr[s]) / pr[s]
+            e_t = np.abs(np.expm1(t_oof[s]) - pr[s]) / pr[s]
+            boot.append((e_t.mean() - e_b.mean()) * 100)
+        lo, hi = np.percentile(boot, [2.5, 97.5])
+        rows.append((raw, d_rnd, d_time, lo, hi, _verdict(lo, hi)))
+    any_real = any(r[5] == "REAL ✓" for r in rows)
+
+    if compact:
+        best = min(rows, key=lambda r: r[2])   # most-negative time ΔMAPE
+        tag = "  <-- WORTH A LOOK" if any_real else ""
+        print(f"{const:<34} cur={str(baseline_val):>6}  best={str(best[0]):>6} "
+              f"Δt={best[2]:+.2f} CI[{best[3]:+.2f},{best[4]:+.2f}]  "
+              f"{'REAL' if any_real else 'noise'}{tag}")
+        return any_real
+
+    print(f"Constant: {const}  (current prod value = {baseline_val!r})\n")
+    hdr = f"{'value':>10} | {'RND ΔMAPE':>10} | {'TIME ΔMAPE':>11} {'time CI(ALL)':>16}  verdict"
+    print(hdr); print("-" * len(hdr))
+    for raw, d_rnd, d_time, lo, hi, v in rows:
+        star = "  *≈current*" if str(raw) == str(baseline_val) else ""
+        print(f"{str(raw):>10} | {d_rnd:>+10.2f} | {d_time:>+11.2f} [{lo:+.2f},{hi:+.2f}]  {v}{star}")
+    print(f"\nTIME-AWARE ΔMAPE by segment (neg=better; baseline = current {baseline_val!r}):")
+    print(f"{'value':>10} | " + "".join(f"{s:>9}" for s in segs))
+    for raw in values:
+        cells = "".join(f"{_mape(cache[raw]['time'], mask_for(s)) - base_mape['time'][s]:>+9.2f}" for s in segs)
+        print(f"{str(raw):>10} | {cells}")
+    if full:
+        print(f"\n[P10,P90] coverage (target 80) by value, time-aware ALL:")
+        for raw in values:
+            print(f"  {raw:>10}: {_coverage(cache[raw]['time'], mask_for('all')):.1f}%")
+    return any_real
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--const", help="e.g. _PLAT_CRED_K or _LGB_PARAMS.num_leaves")
+    ap.add_argument("--values", help="comma-separated values to sweep")
+    ap.add_argument("--all", action="store_true", help="scan the whole watchlist; exit 1 if any flips noise→REAL")
+    ap.add_argument("--full", action="store_true", help="fit low/high too -> pinball + coverage")
+    ap.add_argument("--data", default=None, help="local listings.parquet (else download release)")
+    ap.add_argument("--segments", default="all,Diesel,Petrol,Hybrid,PHEV,EV")
+    args = ap.parse_args()
+    if not args.all and not (args.const and args.values):
+        ap.error("give either --all, or both --const and --values")
+
+    df = load_sold(args.data)
+    fuel = df["fuel_norm"].values
+    segs = [s.strip() for s in args.segments.split(",")]
+    def mask_for(s):
+        return np.ones(len(df), bool) if s == "all" else (fuel == s)
+    folds = {m: _folds(df, m) for m in ("random", "time")}
+    print(f"Loaded {len(df)} sold rows from the release snapshot.\n")
+
+    if args.all:
+        print("WATCHLIST sensitivity scan (time-aware; 'REAL' = data drifted, worth a human look):\n")
+        any_real = False
+        for const, values in _WATCHLIST:
+            try:
+                r = sweep_one(df, folds, segs, mask_for, const,
+                              [v.strip() for v in values.split(",")], args.full, compact=True)
+                any_real = any_real or r
+            except Exception as e:  # noqa: BLE001 — one bad const shouldn't abort the scan
+                print(f"{const:<34} ERROR: {e}")
+        print("\nAll noise → constants are still well-set; nothing to tune."
+              if not any_real else
+              "\nSomething flipped REAL → re-sweep it with --const for detail before changing.")
+        sys.exit(1 if any_real else 0)
+
+    sweep_one(df, folds, segs, mask_for, args.const,
+              [v.strip() for v in args.values.split(",")], args.full, compact=False)
+    print("\nRandom KFold flatters (peeks at contemporaneous sales); trust the "
+          "TIME column. 'noise (CI∋0)' = not worth hand-tuning.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tune_lgb_params.py
+++ b/scripts/tune_lgb_params.py
@@ -1,0 +1,256 @@
+"""Joint, time-aware tuning of the price-model LGB hyperparameters.
+
+Why: the 2026-06-08 watchlist scan (scripts/sweep_constant.py --all) flipped
+num_leaves / max_depth / min_child_samples / reg_lambda all to REAL → the model
+is under-capacity for the grown corpus. Per-knob bests DON'T compose (capacity↑
+wants reg↑ to control variance), so they must be tuned JOINTLY.
+
+Honest protocol (no peeking at the test):
+  1. sort sold rows by deactivated_at; oldest 70% = TUNE, newest 30% = HOLDOUT.
+  2. search: random over 6 LGB params; objective = time-aware 3-fold CV MAPE on TUNE.
+  3. VERDICT: refit current-params vs best-params on ALL of TUNE, evaluate on the
+     untouched HOLDOUT (MAPE + pinball + coverage, bootstrap CI). Only the holdout
+     number is trustworthy — the CV objective is what we optimized against.
+
+Reuses prod feature prep (price_model._prepare_X / _fit_platform_encoding /
+_monotone_constraints) so a tuned param set drops straight into _LGB_PARAMS.
+Writes the recommendation to data/price_lgb_tuned.json for HUMAN REVIEW — does
+NOT modify _LGB_PARAMS or retrain. No optuna dependency (random search).
+
+Usage:  python -m scripts.tune_lgb_params --trials 40
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import lightgbm as lgb
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import TimeSeriesSplit
+
+from src.analytics import price_model as pm
+
+_CACHE = Path("/tmp/olx-release/listings.parquet")
+_OUT = Path(__file__).resolve().parent.parent / "data" / "price_lgb_tuned.json"
+_TUNABLE = ["num_leaves", "max_depth", "min_child_samples",
+            "learning_rate", "reg_lambda", "n_estimators"]
+
+
+def _norm_fuel(s: str) -> str:
+    s = str(s).lower()
+    if "plug" in s: return "PHEV"
+    if "íbrid" in s or "ibrid" in s: return "Hybrid"
+    if "elétr" in s or "eléctr" in s or "electr" in s: return "EV"
+    if "diesel" in s or "asóleo" in s or "asoleo" in s: return "Diesel"
+    if "asolina" in s: return "Petrol"
+    return "Other"
+
+
+def load_sold(data_path: str | None) -> pd.DataFrame:
+    path = Path(data_path) if data_path else _CACHE
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        repo = subprocess.run(["gh", "repo", "view", "--json", "nameWithOwner",
+                               "--jq", ".nameWithOwner"], capture_output=True, text=True,
+                              check=True).stdout.strip()
+        subprocess.run(["gh", "release", "download", "latest-data", "--repo", repo,
+                        "--pattern", "listings.parquet", "--dir", str(path.parent),
+                        "--clobber"], check=True)
+    df = pd.read_parquet(path)
+    df = df[df["deactivation_reason"].astype(str).str.lower() == "sold"].copy()
+    df = df.dropna(subset=["price_eur", "year", "mileage_km"])
+    df["age"] = (2026 - df["year"]).clip(lower=1)
+    df = df[df["price_eur"].between(800, 150000)
+            & df["mileage_km"].between(1000, 500000) & (df["age"] < 25)]
+    df["fuel_norm"] = df["fuel_type"].map(_norm_fuel)
+    df["dt"] = pd.to_datetime(df["deactivated_at"], errors="coerce")
+    return df.dropna(subset=["dt"]).sort_values("dt").reset_index(drop=True)
+
+
+def _make(name, alpha, params):
+    p = dict(params, random_state=42, verbose=-1, n_jobs=-1)
+    if name == "median":
+        return lgb.LGBMRegressor(objective="regression",
+                                 monotone_constraints=pm._monotone_constraints(),
+                                 monotone_constraints_method="advanced", **p)
+    return lgb.LGBMRegressor(objective="quantile", alpha=alpha, **p)
+
+
+_CAT_IDX = None
+def _cat_idx():
+    global _CAT_IDX
+    if _CAT_IDX is None:
+        _CAT_IDX = [pm._ALL_FEATURES.index(c) for c in pm.CATEGORICAL_FEATURES]
+    return _CAT_IDX
+
+
+def _oof(df, y, folds, params, quants):
+    """Leakage-safe OOF preds (platform map fit per fold-train)."""
+    out = {q: np.full(len(df), np.nan) for q in quants}
+    tested = np.zeros(len(df), bool)
+    for tr, te in folds:
+        tr_df, te_df = df.iloc[tr], df.iloc[te]
+        plat = pm._fit_platform_encoding(tr_df, y[tr])
+        x_tr, cm = pm._prepare_X(tr_df, plat_enc=plat)
+        x_te, _ = pm._prepare_X(te_df, cm, plat_enc=plat)
+        for name, alpha in quants.items():
+            m = _make(name, alpha, params)
+            m.fit(x_tr, y[tr], categorical_feature=_cat_idx())
+            out[name][te] = m.predict(x_te)
+        tested[te] = True
+    return out, tested
+
+
+def _fit_predict(tune_df, y_tune, hold_df, params, quants):
+    """Fit on ALL of TUNE, predict HOLDOUT (the untouched test)."""
+    plat = pm._fit_platform_encoding(tune_df, y_tune)
+    x_tr, cm = pm._prepare_X(tune_df, plat_enc=plat)
+    x_te, _ = pm._prepare_X(hold_df, cm, plat_enc=plat)
+    out = {}
+    for name, alpha in quants.items():
+        m = _make(name, alpha, params)
+        m.fit(x_tr, y_tune, categorical_feature=_cat_idx())
+        out[name] = m.predict(x_te)
+    return out
+
+
+def _mape(oof_med, price, mask):
+    p = np.expm1(oof_med)
+    return float(np.mean(np.abs(p[mask] - price[mask]) / price[mask]) * 100)
+
+
+def _pinball(oof_q, price, alpha):
+    p = np.expm1(oof_q); d = price - p
+    return float(np.mean(np.maximum(alpha * d, (alpha - 1) * d)))
+
+
+def _sample(rng):
+    return {
+        "num_leaves": int(rng.integers(15, 201)),
+        "max_depth": int(rng.integers(4, 13)),
+        "min_child_samples": int(rng.integers(3, 61)),
+        "learning_rate": float(np.exp(rng.uniform(np.log(0.02), np.log(0.12)))),
+        "reg_lambda": float(np.exp(rng.uniform(np.log(0.1), np.log(12.0)))),
+        "n_estimators": int(rng.integers(250, 901)),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--trials", type=int, default=40)
+    ap.add_argument("--top", type=int, default=6, help="how many top-CV configs to confirm on the holdout")
+    ap.add_argument("--data", default=None)
+    ap.add_argument("--n-boot", type=int, default=2000)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    rng = np.random.default_rng(args.seed)
+
+    df = load_sold(args.data)
+    cut = int(len(df) * 0.70)
+    tune, hold = df.iloc[:cut].reset_index(drop=True), df.iloc[cut:].reset_index(drop=True)
+    y_tune = np.log1p(np.maximum(tune["price_eur"].values.astype(float), 0))
+    price_h = hold["price_eur"].values.astype(float)
+    fuel_h = hold["fuel_norm"].values
+    print(f"{len(df)} sold rows → TUNE {len(tune)} (oldest 70%) / HOLDOUT {len(hold)} (newest 30%)")
+    print(f"TUNE dt: {tune['dt'].min().date()}..{tune['dt'].max().date()}  "
+          f"HOLDOUT dt: {hold['dt'].min().date()}..{hold['dt'].max().date()}\n")
+
+    tune_folds = list(TimeSeriesSplit(n_splits=3).split(np.arange(len(tune))))
+    MED = {"median": 0.5}
+    ALL = pm._QUANTILES
+
+    current = {k: pm._LGB_PARAMS[k] for k in _TUNABLE if k in pm._LGB_PARAMS}
+    current["n_estimators"] = 400   # match the sweep harness baseline (prod early-stops near here)
+
+    def cv_mape(params):
+        oof, tested = _oof(tune, y_tune, tune_folds, params, MED)
+        return _mape(oof["median"], tune["price_eur"].values.astype(float), tested)
+
+    t0 = time.time()
+    base_cv = cv_mape(current)
+    print(f"current params CV-MAPE (tune, time-aware) = {base_cv:.3f}\ncurrent = {current}\n")
+    print(f"random search, {args.trials} trials (seed {args.seed}) …")
+    trials_log: list[tuple[float, dict]] = []
+    best_cv = base_cv
+    for i in range(args.trials):
+        p = _sample(rng)
+        cv = cv_mape(p)
+        trials_log.append((cv, p))
+        flag = ""
+        if cv < best_cv:
+            best_cv = cv; flag = "  <-- best"
+        print(f"  [{i+1:>3}/{args.trials}] cv-mape={cv:.3f}  nl={p['num_leaves']:>3} "
+              f"md={p['max_depth']:>2} mcs={p['min_child_samples']:>2} "
+              f"lr={p['learning_rate']:.3f} l2={p['reg_lambda']:.2f} ne={p['n_estimators']:>3}{flag}")
+    trials_log.sort(key=lambda t: t[0])
+    print(f"\nsearch done in {time.time()-t0:.0f}s. best CV-MAPE={trials_log[0][0]:.3f} "
+          f"(current {base_cv:.3f}, Δ={trials_log[0][0]-base_cv:+.3f})")
+
+    # ---- CONFIRMATION: do the TOP-K CV configs ALL survive the untouched HOLDOUT? ----
+    # One lucky config clearing the holdout is weak; the whole top-CV region clearing
+    # it is robust. Each top-K config is evaluated on the holdout it never saw.
+    full = np.ones(len(hold), bool)
+    cur_pred = _fit_predict(tune, y_tune, hold, current, ALL)
+    cur_m = _mape(cur_pred["median"], price_h, full)
+    cb = np.expm1(cur_pred["median"])
+    idx = np.arange(len(hold))
+
+    def holdout_delta_ci(pred):
+        bb = np.expm1(pred["median"]); m = _mape(pred["median"], price_h, full)
+        boot = [(np.mean(np.abs(bb[s]-price_h[s])/price_h[s])
+                 - np.mean(np.abs(cb[s]-price_h[s])/price_h[s])) * 100
+                for s in (rng.choice(idx, len(idx), replace=True) for _ in range(args.n_boot))]
+        lo, hi = np.percentile(boot, [2.5, 97.5])
+        v = "SHIP ✓" if hi < 0 else "worse ✗" if lo > 0 else "wash"
+        return m, m - cur_m, lo, hi, v
+
+    print(f"\n=== HOLDOUT confirmation: top-{args.top} CV configs vs current "
+          f"(current holdout MAPE={cur_m:.2f}) ===")
+    print(f"{'rank':>4} {'cvMAPE':>7} {'hMAPE':>6} {'Δ':>6} {'95% CI':>16}  verdict   params")
+    topk_rows = []
+    for rank, (cv, p) in enumerate(trials_log[:args.top], 1):
+        pred = _fit_predict(tune, y_tune, hold, p, ALL)
+        m, d, lo, hi, v = holdout_delta_ci(pred)
+        topk_rows.append({"cv": round(cv, 3), "holdout_mape": round(m, 2),
+                          "delta": round(d, 2), "ci": [round(lo, 2), round(hi, 2)],
+                          "verdict": v, "params": p})
+        ps = f"nl{p['num_leaves']} md{p['max_depth']} mcs{p['min_child_samples']} lr{p['learning_rate']:.3f} l2{p['reg_lambda']:.2f} ne{p['n_estimators']}"
+        print(f"{rank:>4} {cv:>7.3f} {m:>6.2f} {d:>+6.2f} [{lo:+.2f},{hi:+.2f}]  {v:<8} {ps}")
+
+    n_ship = sum(r["verdict"] == "SHIP ✓" for r in topk_rows)
+    n_worse = sum(r["verdict"] == "worse ✗" for r in topk_rows)
+    robust = (topk_rows[0]["verdict"] == "SHIP ✓") and (n_ship >= (args.top + 1) // 2) and n_worse == 0
+    summary = (f"ROBUST ✓ — {n_ship}/{args.top} top configs clear the holdout, 0 worse"
+               if robust else
+               f"FRAGILE — only {n_ship}/{args.top} clear holdout, {n_worse} worse; "
+               f"the win may be a lucky single config")
+    print(f"\nCONFIRMATION: {summary}")
+    # consistency of the top region (is the winning direction stable?)
+    tp = [r["params"] for r in topk_rows]
+    rng_str = lambda k: f"{min(x[k] for x in tp)}–{max(x[k] for x in tp)}"
+    print(f"top-{args.top} param ranges: num_leaves {rng_str('num_leaves')}, "
+          f"max_depth {rng_str('max_depth')}, min_child {rng_str('min_child_samples')}, "
+          f"lr {min(x['learning_rate'] for x in tp):.3f}–{max(x['learning_rate'] for x in tp):.3f}, "
+          f"reg_lambda {min(x['reg_lambda'] for x in tp):.2f}–{max(x['reg_lambda'] for x in tp):.2f}")
+
+    best = topk_rows[0]
+    _OUT.write_text(json.dumps({
+        "tuned_at_utc": None, "seed": args.seed, "trials": args.trials,
+        "tune_rows": len(tune), "holdout_rows": len(hold),
+        "current_params": current, "current_holdout_mape": round(cur_m, 2),
+        "best_params": best["params"], "best_holdout_mape": best["holdout_mape"],
+        "best_holdout_delta_ci": best["ci"], "confirmation": summary,
+        "top_k": topk_rows,
+        "note": "HUMAN REVIEW before editing _LGB_PARAMS. Ship only if ROBUST. "
+                "n_estimators is early-stopped in prod — treat as ceiling hint, not pinned.",
+    }, indent=2))
+    print(f"\nWrote {_OUT}. Ship only if ROBUST; trust holdout, not CV.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/analytics/price_model.py
+++ b/src/analytics/price_model.py
@@ -69,7 +69,12 @@ _OTHER_CATEGORY = "__other__"
 # scan kept running on every train/predict for nothing.
 # v8: drop the dead pipeline + helpers entirely. Bundle no longer carries
 # `text_pipeline`; `_prepare_X` stops fitting a TF-IDF/SVD on every call.
-_SCHEMA_VERSION = 11  # v11: drop {color, drive_type, doors} after 2026-05-10 ablation
+# v12: add `enc_plat` — credibility-smoothed platform target-encoding keyed on
+# brand+generation (no fixed year-band: `generation` already IS the coherent
+# lifecycle unit and the model's `year` feature handles within-gen aging).
+# Marginal/niche signal (see project_mileage_not_the_lever); the platform→price
+# map rides in the bundle (metrics["plat_enc"]) and is stripped from history JSON.
+_SCHEMA_VERSION = 12
 # Fraction of the dataset (newest rows by first_seen_at) used as the
 # time-honest conformal calibration window. Random-KFold CQR mixes
 # time-adjacent rows across folds and over-estimates coverage on real future
@@ -104,6 +109,12 @@ NUMERIC_FEATURES = [
     # 0.003 threshold the team has applied to all soft signals since v7.
     "seller_listings_count_90d",
     "plate_obscured",
+    # v12: credibility-smoothed platform target-encoding keyed on
+    # brand+generation. Injects "what do coherent neighbours sell for" as a
+    # numeric the tree can lean on where a leaf (brand+model+gen+fuel) is
+    # data-starved but the platform isn't. Computed leakage-safe (OOF on train,
+    # persisted map for inference). Small/niche (project_mileage_not_the_lever).
+    "enc_plat",
     # NOTE: price-history features (num_price_drops, max_drop_pct,
     # price_drop_velocity, days_since_last_drop) are intentionally excluded.
     # They are post-hoc — known only after observing the listing for days —
@@ -158,6 +169,12 @@ _ALL_FEATURES = NUMERIC_FEATURES + BOOL_FEATURES + CATEGORICAL_FEATURES
 _MONOTONE_BY_FEATURE: dict[str, int] = {
     "year": 1,
     "mileage_km": -1,
+    # NOTE: enc_plat is intentionally NOT constrained. A +1 prior seems
+    # natural (higher platform price → higher prediction) but backtests showed
+    # it HURTS — the platform mean already bakes in year/mileage averages, so
+    # conditional on those features the relationship isn't cleanly monotone and
+    # the "advanced" constraint method degrades the fit (ALL ΔMAPE +0.04 with
+    # the constraint vs −0.09 without). Left at 0.
 }
 
 
@@ -215,17 +232,100 @@ def _encode_categoricals(
     return out, maps
 
 
+# --- Platform target-encoding (schema v12) ---------------------------------
+# Borrow strength across a COHERENT neighbourhood: same brand + chassis
+# generation (e.g. BMW G30 pools 530e/530d/525d/520d across powertrain).
+# No fixed year-band — `generation` already IS the lifecycle-aware unit (a G30
+# is a G30 whether the gen ran 4 or 7 years) and the model's `year` feature
+# handles within-generation aging; a fixed band only fragments platforms
+# (1246 groups vs 539) for no measurable gain. Credibility-smoothed mean
+# log1p(price) blends toward the global mean for thin platforms (n→0) so a
+# 5-sale platform can't dominate. Leakage-safe: the map is fit on TRAIN targets
+# only (per CV fold, and on the full train set for the persisted inference map);
+# training rows get out-of-fold values. Marginal/niche — see
+# project_mileage_not_the_lever.
+#
+# K = credibility (shrinkage) strength: enc = (Σy + K·gmean)/(n + K), so a
+# platform with n=K sales gets 50% weight on its own mean and thinner ones
+# shrink toward the global mean. MAPE sensitivity is provably FLAT here (swept
+# K∈[0.3, 80] → ALL ΔMAPE −0.05..−0.13, all noise-floor). The Bühlmann
+# data-optimal K* = σ²_within/σ²_between ≈ 0.3 is deliberately NOT used: it
+# barely shrinks (a 2-sale platform would get 0.87 weight on its own noisy
+# mean) — a robustness cost MAPE can't detect because thin platforms are a tiny
+# fraction of rows, yet they're exactly where this feature is supposed to help.
+# 20 is a mid-range value chosen for thin-platform robustness, not MAPE-tuned.
+_PLAT_CRED_K = 20.0
+
+
+def _platform_key(df: pd.DataFrame) -> np.ndarray:
+    """brand|generation — the coherent pooling key (generation = lifecycle unit)."""
+    idx = df.index
+    brand = df["brand"].astype(str) if "brand" in df.columns else pd.Series("NA", index=idx)
+    gen = df["generation"].astype(str) if "generation" in df.columns else pd.Series("NA", index=idx)
+    return brand.values + "|" + gen.values
+
+
+def _fit_platform_encoding(
+    df: pd.DataFrame, y_log: np.ndarray,
+) -> tuple[dict[str, float], float]:
+    """Credibility-smoothed platform → mean-log-price map (+ global-mean fallback)."""
+    keys = _platform_key(df)
+    gmean = float(np.mean(y_log)) if len(y_log) else 0.0
+    grp = pd.DataFrame({"k": keys, "y": y_log}).groupby("k")["y"].agg(["sum", "size"])
+    enc = (grp["sum"] + _PLAT_CRED_K * gmean) / (grp["size"] + _PLAT_CRED_K)
+    return {k: float(v) for k, v in enc.items()}, gmean
+
+
+def _apply_platform_encoding(
+    df: pd.DataFrame, enc_map: dict[str, float], gmean: float,
+) -> np.ndarray:
+    keys = pd.Series(_platform_key(df))
+    return keys.map(enc_map).fillna(gmean).values.astype(float)
+
+
+def _oof_platform_encoding(
+    df: pd.DataFrame, y_log: np.ndarray, n_splits: int = 5,
+) -> np.ndarray:
+    """Out-of-fold platform encoding for TRAINING rows (no self-leakage in the
+    final fit). Each row is encoded from a map fit on the *other* folds."""
+    keys = _platform_key(df)
+    out = np.empty(len(df), dtype=float)
+    n_splits = min(n_splits, max(2, len(df) // 20))
+    kf = KFold(n_splits=n_splits, shuffle=True, random_state=42)
+    for tr, te in kf.split(np.arange(len(df))):
+        gmean = float(np.mean(y_log[tr])) if len(tr) else 0.0
+        grp = pd.DataFrame({"k": keys[tr], "y": y_log[tr]}).groupby("k")["y"].agg(["sum", "size"])
+        enc = ((grp["sum"] + _PLAT_CRED_K * gmean) / (grp["size"] + _PLAT_CRED_K)).to_dict()
+        out[te] = pd.Series(keys[te]).map(enc).fillna(gmean).values
+    return out
+
+
 def _prepare_X(
     df: pd.DataFrame,
     cat_maps: dict[str, dict[str, int]] | None = None,
+    plat_enc: tuple[dict[str, float], float] | None = None,
 ) -> tuple[np.ndarray, dict[str, dict[str, int]]]:
     """Prepare feature matrix from listings DataFrame.
 
     Returns (X_arr, cat_maps). cat_maps is the ordinal-encoding mapping
     fitted on this dataframe; pass it back in to reuse the encoding for
     new rows (CV folds, calibration slice, ``predict_prices``).
+
+    ``plat_enc`` is the (platform_map, global_mean) tuple for the v12
+    ``enc_plat`` feature. If the caller already attached an ``enc_plat`` column
+    (training uses OOF values), it's used as-is. Otherwise the column is
+    computed from ``plat_enc``; with no map it stays NaN and LightGBM treats it
+    as missing (feature inert) — so call sites that don't pass a map keep working.
     """
     X = df.reindex(columns=_ALL_FEATURES).copy()
+
+    if (
+        "enc_plat" in _ALL_FEATURES
+        and "enc_plat" not in df.columns
+        and plat_enc is not None
+    ):
+        enc_map, gmean = plat_enc
+        X["enc_plat"] = _apply_platform_encoding(df, enc_map, gmean)
 
     for col in BOOL_FEATURES:
         if col in X.columns:
@@ -246,14 +346,18 @@ _LGB_PARAMS = dict(
     # the search.  On ~8k rows early stopping was pegged at 699/700 before
     # this bump, meaning the old cap was the bottleneck, not overfitting.
     n_estimators=2000,
-    # max_depth and num_leaves must be consistent: a tree of depth d can have
-    # at most 2^d leaves. With max_depth=4, num_leaves was silently capped at
-    # 16 — depth=6 lets num_leaves=31 actually be reached.
-    max_depth=6,
-    learning_rate=0.05,
-    min_child_samples=10,
-    reg_lambda=1.5,
-    num_leaves=31,
+    # max_depth and num_leaves must be consistent: a tree of depth d has at
+    # most 2^d leaves (2^9=512 ≥ 41, fine).
+    # v12 retune (2026-06-08): joint time-aware random search (scripts/
+    # tune_lgb_params.py, 150 trials), HOLDOUT-confirmed ROBUST (5/8 top-CV
+    # configs clear the untouched newest-30% holdout, 0 worse; ΔMAPE −0.32, CI
+    # [−0.48,−0.16]). As the corpus grew, the old shallow/fast config was
+    # under-capacity; deeper + slower-learning wins. See data/price_lgb_tuned.json.
+    max_depth=9,           # was 6
+    learning_rate=0.023,   # was 0.05
+    min_child_samples=8,   # was 10
+    reg_lambda=0.73,       # was 1.5
+    num_leaves=41,         # was 31
     random_state=42,
     verbose=-1,
     n_jobs=-1,
@@ -907,9 +1011,11 @@ def _cv_metrics(
     for fold_idx, (train_idx, val_idx) in enumerate(kf.split(df)):
         train_df = df.iloc[train_idx]
         val_df = df.iloc[val_idx]
-        # Encode categoricals on train only — no leakage into the val fold.
-        X_train, cat_maps_fold = _prepare_X(train_df)
-        X_val, _ = _prepare_X(val_df, cat_maps_fold)
+        # Encode categoricals AND the platform target-encoding on train only —
+        # no leakage into the val fold (val rows get the train-fold map).
+        plat_enc_fold = _fit_platform_encoding(train_df, y_log[train_idx])
+        X_train, cat_maps_fold = _prepare_X(train_df, plat_enc=plat_enc_fold)
+        X_val, _ = _prepare_X(val_df, cat_maps_fold, plat_enc=plat_enc_fold)
         y_train_log = y_log[train_idx]
         y_val_log = y_log[val_idx]
         sw_train = sample_weight_all[train_idx]
@@ -1263,6 +1369,19 @@ def train_price_model(
         uncertainty_bundle, cv_perm_df, cv_grouped_df, cv_shap_df,
     ) = _cv_metrics(df)
     metrics["filter_stats"] = filter_stats
+
+    # v12 platform target-encoding. Persist the full-train map for inference
+    # (predict_prices), and attach OOF values as the training column so the
+    # final fit below doesn't memorize each row's own platform mean.
+    plat_map, plat_gmean = _fit_platform_encoding(df, y_log)
+    df = df.copy()
+    df["enc_plat"] = _oof_platform_encoding(df, y_log)
+    metrics["plat_enc"] = {
+        "map": plat_map,
+        "gmean": plat_gmean,
+        "cred_k": _PLAT_CRED_K,
+    }
+
     n_sold = int((sold_w != 1.0).sum())
     n_dropped_sold = int((sold_w == 0.0).sum())
     metrics["sold_inclusion"] = {
@@ -1315,6 +1434,7 @@ def predict_prices(
     conformal_q_per_bucket: dict[str, float] | None = None,
     conformal_q_bucket_edges: list[tuple[float, float, str]] | None = None,
     uncertainty_bundle: tuple[lgb.LGBMRegressor, float] | None = None,
+    plat_enc: tuple[dict[str, float], float] | None = None,
 ) -> pd.DataFrame:
     """Predict fair price range for each listing.
 
@@ -1341,8 +1461,11 @@ def predict_prices(
     applied to the median for new rows only (OOF preds are already
     calibrated). The band assembly below brackets the calibrated median by
     min/max so isotonic-induced crossings don't leak into the [low, high].
+
+    *plat_enc* — (platform_map, global_mean) for the v12 ``enc_plat`` feature,
+    read from ``metrics["plat_enc"]``. None → the feature stays NaN (inert).
     """
-    X_arr, _ = _prepare_X(listings_df, cat_maps)
+    X_arr, _ = _prepare_X(listings_df, cat_maps, plat_enc=plat_enc)
 
     # Model output is in log1p(price) space.
     log_median = models["median"].predict(X_arr)
@@ -1606,7 +1729,11 @@ def save_model(
         "saved_at": datetime.now(timezone.utc).isoformat(),
     }
     joblib.dump(bundle, _MODEL_PATH)
-    _append_metrics(metrics)
+    # The v12 platform map (potentially thousands of entries, numpy floats)
+    # lives in the joblib bundle's metrics. Strip it from the history JSON —
+    # it would bloat the file 100× and isn't JSON-serializable as-is.
+    history_metrics = {k: v for k, v in metrics.items() if k != "plat_enc"}
+    _append_metrics(history_metrics)
 
 
 def load_model(

--- a/src/cli.py
+++ b/src/cli.py
@@ -1576,6 +1576,8 @@ def _load_predictions_for_model_consumers(active: "pd.DataFrame"):
     models, cat_maps, metrics, oof_preds, calibrator, uncertainty = saved
     edges_raw = metrics.get("conformal_q_bucket_edges")
     bucket_edges = [tuple(e) for e in edges_raw] if edges_raw else None
+    plat_enc_raw = metrics.get("plat_enc")
+    plat_enc = (plat_enc_raw["map"], plat_enc_raw["gmean"]) if plat_enc_raw else None
     return predict_prices(
         models, cat_maps, active,
         conformal_q=metrics.get("conformal_q", 0.0),
@@ -1584,6 +1586,7 @@ def _load_predictions_for_model_consumers(active: "pd.DataFrame"):
         conformal_q_per_bucket=metrics.get("conformal_q_per_bucket"),
         conformal_q_bucket_edges=bucket_edges,
         uncertainty_bundle=uncertainty,
+        plat_enc=plat_enc,
     )
 
 

--- a/src/dashboard/data_loader.py
+++ b/src/dashboard/data_loader.py
@@ -812,6 +812,12 @@ def compute_signals(
         _bucket_edges = (
             [tuple(e) for e in _bucket_edges_raw] if _bucket_edges_raw else None
         )
+        # v12 platform target-encoding map (brand+generation → mean log-price).
+        # predict_prices builds the enc_plat column from it.
+        _plat_enc_raw = _gb_metrics.get("plat_enc") if _gb_metrics else None
+        _plat_enc = (
+            (_plat_enc_raw["map"], _plat_enc_raw["gmean"]) if _plat_enc_raw else None
+        )
         # OOF preds (built during CV training) override model.predict for any
         # listing the model was trained on, so the deal-scoring loop compares
         # asking price against an out-of-fold "fair price" rather than an
@@ -827,6 +833,7 @@ def compute_signals(
             conformal_q_per_bucket=_per_bucket_q,
             conformal_q_bucket_edges=_bucket_edges,
             uncertainty_bundle=_gb_uncertainty,
+            plat_enc=_plat_enc,
         )
         _cs_step(f"predict_prices(active n={len(active)})")
         if "olx_id" in active.columns:
@@ -878,6 +885,7 @@ def compute_signals(
                     conformal_q_per_bucket=_per_bucket_q,
                     conformal_q_bucket_edges=_bucket_edges,
                     uncertainty_bundle=_gb_uncertainty,
+                    plat_enc=_plat_enc,
                 )
                 _cs_step(f"predict_prices(sold n={len(sold_only)})")
                 sold_olx_ids = sold_only["olx_id"].reindex(sold_pred_df.index).values


### PR DESCRIPTION
## What

Outcome of a long price-model investigation (most ideas turned out noise-floor; one real win):

1. **`enc_plat` (schema v12)** — credibility-smoothed `brand+generation` target-encoding (coherent-platform pooling, e.g. BMW G30 530e/530d/525d). Leakage-safe (per-fold OOF on train + persisted map for inference). Honest verdict: a noise-floor add on the time-aware holdout, kept inert where it doesn't help.
2. **`_LGB_PARAMS` retune — the one real win.** Joint time-aware random search, **holdout-confirmed ROBUST** (5/8 top-CV configs clear the untouched newest-30% holdout, 0 worse; ΔMAPE −0.32, CI [−0.48,−0.16]). The model was under-capacity as the corpus grew → deeper + slower-learning: `max_depth 6→9, lr 0.05→0.023, num_leaves 31→41, min_child_samples 10→8, reg_lambda 1.5→0.73`. `n_estimators` kept at the 2000 ceiling + early-stop (NOT pinned to the tuned 673).
3. **Tooling** — `scripts/sweep_constant.py` (sensitivity harness: evidence-check any constant, time-aware + bootstrap → noise/real verdict, `--all` watchlist), `scripts/tune_lgb_params.py` (joint tuner, tune-70/holdout-30), `.github/workflows/sensitivity.yml` (weekly watchlist scan, fails+notifies on noise→REAL).

## ⚠️ Deploy ordering (must read)

schema bump 11→12 ⇒ `load_model` rejects the current **v11** release bundle. **A `train-model` retrain must put a v12 bundle into the `latest-data` release BEFORE this merges to master**, otherwise the dashboard loses all price predictions until the next scrape.

Sequence: retrain on the scrape host (v12 code → v12 `price_model.joblib` → upload to `latest-data`) → verify → **then** merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
