### PR TITLE
price-model: missing-feature abstention + spec-dropout training (kill phantom BUYs)

### DIFF
--- a/scripts/exp_feature_dropout.py
+++ b/scripts/exp_feature_dropout.py
@@ -1,0 +1,220 @@
+"""EXPERIMENT (2026-06-09): should missingness-aware (spec-dropout) training
+ship? Promotes scripts/proto_feature_dropout.py to a decision-grade test.
+
+Root cause (audit 2026-06-08, see project_missing_feature_overprediction): the
+price model leans ~70% on coarse baseline features; when the per-car specs
+{mileage, horsepower, engine_cc, fuel_type} are absent it falls back to that
+baseline and over-predicts behind a deceptively tight band (its NaN branches
+are under-trained — ~97% of training rows are full-feature).
+
+Hypothesis: randomly NaN-ing a RANDOM SUBSET of specs on a fraction of TRAIN
+rows teaches (a) the median head an honest lower marginal and (b) the low/high
+CQR heads to WIDEN when specs are absent — restoring coverage there — at ~no
+cost on full-feature rows.
+
+Three things the prototype lacked, added here for a ship decision:
+  1. REALISTIC dropout — per touched row, drop k∈{1,2,3,4} random specs (not
+     always all 4), covering the real combinatorial missing patterns.
+  2. BOOTSTRAP CIs on every delta (dropout − baseline), like tune_lgb_params.
+  3. CQR CHECK — a real conformal q is calibrated on a held-back CALIB slice
+     (full-feature, as in prod) and we verify 80% coverage is preserved on the
+     FULL holdout (must not break — project_cqr_calibration) while improving on
+     the stripped holdout.
+
+Protocol (trust the HOLDOUT, not the training objective):
+  sold rows sorted by deactivated_at →
+    HOLDOUT  = newest 30%   (never seen)
+    TRAIN    = oldest 70%, split into
+      FIT    = oldest 80% of TRAIN  (model fit)
+      CALIB  = newest 20% of TRAIN  (conformal q, full-feature — time-honest)
+  baseline arm: FIT as-is.  dropout arm: FIT with random spec-dropout.
+  enc_plat + cat_maps fit once on FIT (dropout doesn't touch brand/generation),
+  shared by both arms so the ONLY difference is the augmentation.
+
+Usage:  python -m scripts.exp_feature_dropout --drop-frac 0.40 --n-boot 2000 --seed 42
+"""
+from __future__ import annotations
+
+import argparse
+
+import lightgbm as lgb
+import numpy as np
+
+from src.analytics import price_model as pm
+from scripts.tune_lgb_params import load_sold
+
+SPECS = ["mileage_km", "horsepower", "engine_cc", "fuel_type"]
+QUANTS = {"median": 0.5, "low": 0.1, "high": 0.9}
+COV_ALPHA = 0.80          # target CQR coverage
+PHANTOM_MULT = 1.3        # "looks like a 30%+ deal": predicted > 1.3 × actual
+_CAT = None
+
+
+def _cat_idx():
+    global _CAT
+    if _CAT is None:
+        _CAT = [pm._ALL_FEATURES.index(c) for c in pm.CATEGORICAL_FEATURES]
+    return _CAT
+
+
+def _make(name, alpha, params):
+    p = dict(params, random_state=42, verbose=-1, n_jobs=-1)
+    if name == "median":
+        return lgb.LGBMRegressor(objective="regression",
+                                 monotone_constraints=pm._monotone_constraints(),
+                                 monotone_constraints_method="advanced", **p)
+    return lgb.LGBMRegressor(objective="quantile", alpha=alpha, **p)
+
+
+def _random_dropout(df, frac, rng):
+    """Copy of df with a random subset of specs NaN'd on `frac` of rows.
+    Per touched row: k ~ Uniform{1..4} specs dropped (covers all patterns,
+    including the all-4 'fully stripped' case prod sees)."""
+    d = df.copy()
+    n = len(d)
+    touched = rng.random(n) < frac
+    idx = np.flatnonzero(touched)
+    for i in idx:
+        k = rng.integers(1, len(SPECS) + 1)
+        for c in rng.choice(SPECS, size=k, replace=False):
+            d.iat[i, d.columns.get_loc(c)] = np.nan
+    return d, touched.sum()
+
+
+def _strip(df, cols):
+    d = df.copy()
+    for c in cols:
+        d[c] = np.nan
+    return d
+
+
+def _fit(fit_df, y, params, plat, cm):
+    out = {}
+    x, _ = pm._prepare_X(fit_df, cm, plat_enc=plat)
+    for name, alpha in QUANTS.items():
+        m = _make(name, alpha, params)
+        m.fit(x, y, categorical_feature=_cat_idx())
+        out[name] = m
+    return out
+
+
+def _pred_log(models, df, plat, cm):
+    """Raw quantile predictions in LOG space (CQR widening applied later)."""
+    x, _ = pm._prepare_X(df, cm, plat_enc=plat)
+    lo, hi = models["low"].predict(x), models["high"].predict(x)
+    return {"med": models["median"].predict(x),
+            "lo": np.minimum(lo, hi), "hi": np.maximum(lo, hi)}
+
+
+def _conformal_q(pred_log, y_log, alpha=COV_ALPHA):
+    """Symmetric additive CQR conformity score on a calibration slice:
+    q = the alpha-quantile (finite-sample-corrected) of
+    E_i = max(lo_i − y_i, y_i − hi_i)."""
+    e = np.maximum(pred_log["lo"] - y_log, y_log - pred_log["hi"])
+    n = len(e)
+    level = min(1.0, np.ceil((n + 1) * alpha) / n)
+    return float(np.quantile(e, level))
+
+
+def _metrics(pred_log, actual, q):
+    """All evaluation metrics for one arm/regime as a dict (no refit)."""
+    med = np.expm1(pred_log["med"])
+    lo = np.expm1(pred_log["lo"] - q)
+    hi = np.expm1(pred_log["hi"] + q)
+    y_log = np.log1p(actual)
+    return {
+        "mape": np.mean(np.abs(med - actual) / actual) * 100,
+        "ratio": np.median(med / actual),          # over-prediction (1.0 = unbiased)
+        "phantom": np.mean(med > PHANTOM_MULT * actual) * 100,
+        "cover": np.mean((y_log >= pred_log["lo"] - q) & (y_log <= pred_log["hi"] + q)) * 100,
+        "mpiw": np.median((hi - lo) / np.maximum(med, 1)) * 100,
+    }
+
+
+def _metric_on(pred_log, actual, q, sel):
+    sub = {k: v[sel] for k, v in pred_log.items()}
+    return _metrics(sub, actual[sel], q)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--drop-frac", type=float, default=0.40, help="fraction of FIT rows touched by dropout")
+    ap.add_argument("--n-boot", type=int, default=2000)
+    ap.add_argument("--n-estimators", type=int, default=1000, help="fixed (no early stop); equal for both arms")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--data", default=None)
+    args = ap.parse_args()
+    rng = np.random.default_rng(args.seed)
+
+    df = load_sold(args.data)
+    h_cut = int(len(df) * 0.70)
+    train, hold = df.iloc[:h_cut].reset_index(drop=True), df.iloc[h_cut:].reset_index(drop=True)
+    f_cut = int(len(train) * 0.80)
+    fit, calib = train.iloc[:f_cut].reset_index(drop=True), train.iloc[f_cut:].reset_index(drop=True)
+    y_fit = np.log1p(np.maximum(fit["price_eur"].values.astype(float), 0))
+    y_cal = np.log1p(np.maximum(calib["price_eur"].values.astype(float), 0))
+    actual = hold["price_eur"].values.astype(float)
+
+    params = {k: pm._LGB_PARAMS[k] for k in pm._LGB_PARAMS}
+    params["n_estimators"] = args.n_estimators
+    print(f"{len(df)} sold rows → FIT {len(fit)} / CALIB {len(calib)} / HOLDOUT {len(hold)}")
+    print(f"dropout: {args.drop_frac:.0%} of FIT rows, k∈{{1..4}} random specs each; "
+          f"n_estimators={args.n_estimators}, bootstrap={args.n_boot}\n")
+
+    # enc_plat + cat_maps from FIT (unaffected by dropout — keys are brand|gen).
+    plat = pm._fit_platform_encoding(fit, y_fit)
+    _, cm = pm._prepare_X(fit, plat_enc=plat)
+
+    base = _fit(fit, y_fit, params, plat, cm)
+    fit_drop, n_touched = _random_dropout(fit, args.drop_frac, rng)
+    drop = _fit(fit_drop, y_fit, params, plat, cm)
+    print(f"dropout touched {n_touched}/{len(fit)} FIT rows\n")
+
+    # conformal q calibrated on full-feature CALIB (as in prod).
+    qb = _conformal_q(_pred_log(base, calib, plat, cm), y_cal)
+    qd = _conformal_q(_pred_log(drop, calib, plat, cm), y_cal)
+    print(f"conformal q (log-space, 80% target): baseline={qb:.4f}  dropout={qd:.4f}\n")
+
+    # Regimes on the holdout: which specs are NaN'd before predicting.
+    regimes = {
+        "FULL (specs present)": [],
+        "mileage only NaN": ["mileage_km"],
+        "mileage+hp NaN": ["mileage_km", "horsepower"],
+        "all 4 specs NaN": SPECS,
+    }
+    idx = np.arange(len(hold))
+    boots = [rng.choice(idx, len(idx), replace=True) for _ in range(args.n_boot)]
+
+    def ci(arr):
+        lo, hi = np.percentile(arr, [2.5, 97.5])
+        return lo, hi
+
+    METS = [("ratio", "P50/act"), ("mape", "MAPE%"), ("phantom", "phantom%"),
+            ("cover", "cover%"), ("mpiw", "band%")]
+    for label, drop_cols in regimes.items():
+        hb = _strip(hold, drop_cols) if drop_cols else hold
+        pb = _pred_log(base, hb, plat, cm)
+        pd_ = _pred_log(drop, hb, plat, cm)
+        mb, md = _metrics(pb, actual, qb), _metrics(pd_, actual, qd)
+        # bootstrap: one metric dict per arm per resample, then deltas per key.
+        acc = {key: np.empty(len(boots)) for key, _ in METS}
+        for j, b in enumerate(boots):
+            bb, bd = _metric_on(pb, actual, qb, b), _metric_on(pd_, actual, qd, b)
+            for key, _ in METS:
+                acc[key][j] = bd[key] - bb[key]
+        print(f"=== {label} ===")
+        print(f"  {'metric':9} {'baseline':>9} {'dropout':>9} {'Δ(drop−base)':>14} {'95% CI':>18}")
+        for key, name in METS:
+            lo, hi = ci(acc[key])
+            d = md[key] - mb[key]
+            sig = "" if (lo < 0 < hi) else (" ↓" if hi < 0 else " ↑")
+            print(f"  {name:9} {mb[key]:>9.2f} {md[key]:>9.2f} {d:>+14.2f} "
+                  f"[{lo:+.2f}, {hi:+.2f}]{sig}")
+        print()
+
+    print("Read: FULL must show no harm (MAPE Δ≈0, cover stays ~80). Stripped regimes")
+    print("should show phantom% ↓ and cover% ↑ with CIs excluding 0. ↓/↑ = CI excludes 0.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/analytics/decision.py
+++ b/src/analytics/decision.py
@@ -262,6 +262,26 @@ _HOLDING_COST_EUR_PER_DAY = 1.30
 _DEFAULT_HOLD_DAYS = 45
 _BUY_SCORE = 18.0
 _WATCH_SCORE = 15.0
+# Low-feature-confidence penalty (audit 2026-06-08). When the
+# discriminative per-car features are absent the price model collapses to a
+# coarse brand+generation+year baseline (enc_plat alone is 54% of model
+# gain) and over-predicts — yet still ships a deceptively tight CQR band
+# because it was trained on ~97% full-feature rows, so its NaN branches are
+# under-trained. Measured for Renault Mégane ST Mk4: P50/ask = 0.95 with
+# mileage present (n=62) vs 1.87 with mileage absent (n=2). A 2017 with no
+# km was valued at €17.5k against an €11k segment median → phantom 52%
+# "deal" that scored BUY 46.5. We don't trust the model's band there —
+# widen it (so borderline rows cross the _BAND_WIDE gate into NO_OPINION)
+# and cut confidence as a floor for rows that shipped no band.
+#
+# Two triggers: a missing odometer (the validated, high-precision case) and
+# a low ``spec_fill`` (≤1 of the {mileage, horsepower, engine, fuel} specs
+# present — a stripped listing the model could only baseline-guess). The
+# spec-fill trigger is the conservative extension; the odometer one carries
+# the evidence.
+_LOW_FEATURE_BAND_ADD = 0.12    # absolute, added to band_frac
+_LOW_FEATURE_CONF = 0.55        # multiplier on final confidence
+_MIN_SPEC_FILL = 0.5            # need ≥2 of 4 discriminative specs present
 # Anomaly hard-gate (feature-space outlier from
 # ``src.analytics.anomaly``). 0.90 keeps v2's contamination=0.05
 # top-tail but only rejects on the very tip — plenty of legitimately
@@ -296,6 +316,10 @@ def decide(
     still carry sev-2 / repair flags that affect economics.
     """
     g = listing.get if hasattr(listing, "get") else lambda k, d=None: listing[k] if k in listing else d
+    # Membership probe so we can tell "column present but NaN" (a real
+    # missing-odometer signal) apart from "column absent entirely" (a caller
+    # that simply doesn't carry mileage — must not be penalised).
+    _has = (lambda k: k in listing.index) if hasattr(listing, "index") else (lambda k: k in listing)
     reasons: list[str] = []
     components: dict[str, float | None] = {}
 
@@ -367,8 +391,44 @@ def decide(
         reasons.append(f"only {sample} comparables (need ≥{_MIN_SAMPLE})")
         return Decision(VERDICT_NO_OPINION, 0.0, reasons, components)
 
-    # ---- Step 3: band confidence.
+    # ---- Step 2b: feature-completeness gate. Two triggers (see the
+    # _LOW_FEATURE_* note above). (1) Missing odometer: explicit
+    # ``mileage_missing`` flag from signals_df wins, else infer from a
+    # present-but-NaN ``mileage_km``. A column absent entirely (raw
+    # listings_df rows / unit fixtures that never carried mileage) is treated
+    # as present so we don't penalise callers that simply don't pass it.
+    # (2) Low ``spec_fill`` — fewer than _MIN_SPEC_FILL of the discriminative
+    # specs present (None when the prediction shipped no fill → no trigger).
+    mileage_missing = False
+    if _is_truthy(g("mileage_missing")):
+        mileage_missing = True
+    elif _has("mileage_km"):
+        mv = g("mileage_km")
+        mileage_missing = mv is None or pd.isna(mv)
+
+    spec_fill = g("spec_fill")
+    has_spec_fill = spec_fill is not None and pd.notna(spec_fill)
+    low_spec = has_spec_fill and float(spec_fill) < _MIN_SPEC_FILL
+    low_feature_conf = mileage_missing or low_spec
+    if low_feature_conf:
+        if mileage_missing:
+            components["mileage_missing"] = True
+        if has_spec_fill:
+            components["spec_fill"] = round(float(spec_fill), 2)
+        why = ("odometer missing" if mileage_missing
+               else f"only {float(spec_fill):.0%} of key specs present")
+        reasons.append(
+            f"{why} — model could only baseline-guess; band widened + confidence cut"
+        )
+
+    # ---- Step 3: band confidence. Low-feature-confidence rows get their
+    # band widened first: the model can't see the discriminative specs, so
+    # its CQR interval understates the true spread. Widening before the gate
+    # routes borderline rows into NO_OPINION instead of letting an inflated
+    # prediction ride a deceptively tight band.
     band_conf = 1.0
+    if low_feature_conf and band_frac is not None:
+        band_frac += _LOW_FEATURE_BAND_ADD
     if band_frac is not None:
         components["band_pct"] = band_frac * 100
         if band_frac > _BAND_WIDE:
@@ -546,7 +606,13 @@ def decide(
     expected_profit_pct = (expected_profit / predicted_corrected) * 100 if predicted_corrected else 0.0
 
     sample_conf = min(sample / _SAMPLE_CONF_DIVISOR, 1.0)
-    confidence = band_conf * sample_conf * calibration_conf * motivated_conf * velocity_conf
+    # Low-feature-confidence floor — bites even when no band shipped
+    # (band-widening above is a no-op then), so the penalty can't be bypassed.
+    feature_conf = _LOW_FEATURE_CONF if low_feature_conf else 1.0
+    confidence = (
+        band_conf * sample_conf * calibration_conf
+        * motivated_conf * velocity_conf * feature_conf
+    )
     score = expected_profit_pct * confidence
 
     components["expected_profit_eur"] = round(expected_profit, 0)

--- a/src/analytics/price_model.py
+++ b/src/analytics/price_model.py
@@ -158,6 +158,18 @@ CATEGORICAL_FEATURES = [
 
 _ALL_FEATURES = NUMERIC_FEATURES + BOOL_FEATURES + CATEGORICAL_FEATURES
 
+# Per-car "spec" features a buyer needs to value a car and that the model
+# uses for the fine-grained adjustment away from the coarse
+# brand+generation+year baseline (enc_plat alone is ~54% of model gain).
+# These are also the features that actually go missing in scraped listings
+# — year/brand/model/generation are ~always present, enc_plat is derived.
+# When too few are present the model collapses to the coarse baseline and
+# over-predicts with a deceptively tight band (audit 2026-06-08: a Mégane
+# with no odometer predicted at €17.5k vs €11k market). Consumers read the
+# ``spec_fill`` column predict_prices emits and abstain below a threshold —
+# see ``decision._MIN_SPEC_FILL``.
+DISCRIMINATIVE_SPEC_FEATURES = ["mileage_km", "horsepower", "engine_cc", "fuel_type"]
+
 
 # --- Monotonic constraints -------------------------------------------------
 # Domain priors: more mileage / damage / RHD / taxi-rental → cheaper; newer /
@@ -489,6 +501,44 @@ def _compute_sample_weights(y_price: np.ndarray) -> np.ndarray:
 _QUANTILES = {"low": 0.1, "median": 0.5, "high": 0.9}
 _EARLY_STOPPING_ROUNDS = 40
 _MIN_N_ESTIMATORS = 50
+
+# Missingness-aware training (project_missing_feature_overprediction, shipped
+# 2026-06-09). On a fraction of the *fitting* rows (each CV fold + the final
+# fit) we NaN a random subset (k∈{1..K}) of DISCRIMINATIVE_SPEC_FEATURES, so the
+# median head learns an honest lower marginal and the low/high CQR heads learn
+# to WIDEN when the per-car specs are absent — instead of collapsing to the
+# coarse enc_plat+year baseline behind a deceptively tight band. Validated on a
+# time-aware holdout (scripts/exp_feature_dropout.py): at frac 0.25 the stripped-
+# row phantom-deal rate falls 34-41%→~16% and CQR coverage 70%→~80% is restored,
+# at ~zero full-feature cost (MAPE Δ +0.02 [-0.21,+0.28]), robust across seeds.
+# No new feature → no schema bump. Set frac to 0.0 to disable. The dropout is
+# applied to fitting data ONLY (never to val/OOF/calibration rows, which keep
+# real features so metrics + conformal q reflect honest serving behaviour).
+_SPEC_DROPOUT_FRAC = 0.25
+_SPEC_DROPOUT_SEED = 1234
+
+
+def _apply_spec_dropout(
+    df: pd.DataFrame, frac: float, rng: np.random.Generator,
+) -> pd.DataFrame:
+    """Return a copy of ``df`` with a random subset (k∈{1..K}) of the
+    discriminative spec features NaN'd on ``frac`` of rows. Training-time
+    augmentation only; the original is untouched and other columns
+    (brand/generation → enc_plat, already attached) are preserved."""
+    cols = [c for c in DISCRIMINATIVE_SPEC_FEATURES if c in df.columns]
+    if frac <= 0 or not cols:
+        return df
+    d = df.copy()
+    for c in cols:
+        if d[c].dtype.kind in "iu":      # int → float so NaN is assignable
+            d[c] = d[c].astype("float64")
+    locs = [d.columns.get_loc(c) for c in cols]
+    touched = np.flatnonzero(rng.random(len(d)) < frac)
+    for i in touched:
+        k = int(rng.integers(1, len(cols) + 1))
+        for j in rng.choice(locs, size=k, replace=False):
+            d.iat[int(i), int(j)] = np.nan
+    return d
 
 
 def _pinball_loss(y_true: np.ndarray, y_pred: np.ndarray, alpha: float) -> float:
@@ -1014,7 +1064,16 @@ def _cv_metrics(
         # Encode categoricals AND the platform target-encoding on train only —
         # no leakage into the val fold (val rows get the train-fold map).
         plat_enc_fold = _fit_platform_encoding(train_df, y_log[train_idx])
-        X_train, cat_maps_fold = _prepare_X(train_df, plat_enc=plat_enc_fold)
+        # Fit the categorical maps on the FULL train fold (no category loss),
+        # then build the fitting matrix from a spec-dropout-augmented copy.
+        # enc_plat is computed from brand|generation (untouched by dropout), so
+        # the augmentation only blanks per-car spec cells. val rows keep real
+        # features → OOF preds + conformal q reflect honest serving behaviour.
+        _, cat_maps_fold = _prepare_X(train_df, plat_enc=plat_enc_fold)
+        train_df_aug = _apply_spec_dropout(
+            train_df, _SPEC_DROPOUT_FRAC, np.random.default_rng(_SPEC_DROPOUT_SEED + fold_idx),
+        )
+        X_train, _ = _prepare_X(train_df_aug, cat_maps_fold, plat_enc=plat_enc_fold)
         X_val, _ = _prepare_X(val_df, cat_maps_fold, plat_enc=plat_enc_fold)
         y_train_log = y_log[train_idx]
         y_val_log = y_log[val_idx]
@@ -1391,8 +1450,15 @@ def train_price_model(
         "active_rows": len(df) - n_sold,
     }
 
-    # Final models: fit on full filtered data with CV-tuned per-quantile iters
-    X_arr, cat_maps = _prepare_X(df)
+    # Final models: fit on full filtered data with CV-tuned per-quantile iters.
+    # Ship cat_maps fit on the full data (no category loss), but fit the models
+    # on a spec-dropout-augmented copy — the OOF enc_plat column is preserved
+    # (dropout only blanks per-car spec cells). See _SPEC_DROPOUT_FRAC.
+    _, cat_maps = _prepare_X(df)
+    df_aug = _apply_spec_dropout(
+        df, _SPEC_DROPOUT_FRAC, np.random.default_rng(_SPEC_DROPOUT_SEED),
+    )
+    X_arr, _ = _prepare_X(df_aug, cat_maps)
     cat_indices = [_ALL_FEATURES.index(c) for c in CATEGORICAL_FEATURES]
 
     models = {}
@@ -1534,11 +1600,16 @@ def predict_prices(
         stacked = np.sort(np.stack([low, median, high]), axis=0)
         low, median, high = stacked[0], stacked[1], stacked[2]
 
-    return pd.DataFrame({
+    out = pd.DataFrame({
         "predicted_price": np.maximum(median, 0),
         "fair_price_low": np.maximum(low, 0),
         "fair_price_high": np.maximum(high, 0),
     }, index=listings_df.index).round(0)
+    # Discriminative-spec completeness rides with the prediction so every
+    # consumer (deal feed, decide(), dashboard) can abstain on rows the
+    # model could only baseline-guess. Kept unrounded (0–1).
+    out["spec_fill"] = spec_feature_fill(listings_df).reindex(out.index).values
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -1839,6 +1910,24 @@ def compute_feature_completeness(listings_df: pd.DataFrame) -> pd.Series:
         return pd.Series(0.0, index=listings_df.index, name="feature_fill_rate")
     present = listings_df[cols].notna().sum(axis=1)
     return (present / len(_ALL_FEATURES)).rename("feature_fill_rate")
+
+
+def spec_feature_fill(listings_df: pd.DataFrame) -> pd.Series:
+    """Fraction (0–1) of the discriminative per-car spec features present.
+
+    Unlike ``compute_feature_completeness`` (which dilutes the signal across
+    all ~20 model features, most of which are derived/always-present), this
+    counts only ``DISCRIMINATIVE_SPEC_FEATURES`` — the spec fields whose
+    absence makes the model fall back to its coarse baseline. ``decide()``
+    abstains when this drops below ``_MIN_SPEC_FILL``.
+    """
+    cols = [c for c in DISCRIMINATIVE_SPEC_FEATURES if c in listings_df.columns]
+    if not cols:
+        # No spec columns at all → unknown, not "empty". Return NaN so
+        # downstream treats it as "no signal" rather than "fully missing".
+        return pd.Series(np.nan, index=listings_df.index, name="spec_fill")
+    present = listings_df[cols].notna().sum(axis=1)
+    return (present / len(DISCRIMINATIVE_SPEC_FEATURES)).rename("spec_fill")
 
 
 def compute_data_completeness(

--- a/src/dashboard/data_loader.py
+++ b/src/dashboard/data_loader.py
@@ -782,6 +782,7 @@ def compute_signals(
     gb_predictions: dict[str, float] = {}
     gb_fair_low: dict[str, float] = {}
     gb_fair_high: dict[str, float] = {}
+    gb_spec_fill: dict[str, float] = {}
     # TreeSHAP attribution of the median price prediction. Populated only
     # for active listings (the sold-side block doesn't compute contribs —
     # dashboard surfaces them on deal cards, which are active by
@@ -841,11 +842,15 @@ def compute_signals(
             preds = price_df["predicted_price"].values
             lows = price_df["fair_price_low"].values
             highs = price_df["fair_price_high"].values
-            for oid, pred, lo, hi in zip(olx_ids, preds, lows, highs):
+            fills = (price_df["spec_fill"].values if "spec_fill" in price_df.columns
+                     else [None] * len(preds))
+            for oid, pred, lo, hi, fill in zip(olx_ids, preds, lows, highs, fills):
                 if oid and pred > 0:
                     gb_predictions[oid] = float(pred)
                     gb_fair_low[oid] = float(lo)
                     gb_fair_high[oid] = float(hi)
+                    if fill is not None and pd.notna(fill):
+                        gb_spec_fill[oid] = float(fill)
 
         # Per-listing feature attribution for the deal-card "why this
         # price?" expander. TreeSHAP on the median model — fast (one tree
@@ -1247,6 +1252,15 @@ def compute_signals(
             "city": listing.get("city", ""),
             "district": listing.get("district", ""),
             "mileage_km": mileage,
+            # Explicit missing-odometer flag for decide(): in high-mileage PT
+            # segments a null odometer makes the price model over-predict
+            # (it can't apply depreciation), so decide() widens the band +
+            # cuts confidence on these rows.
+            "mileage_missing": bool(pd.isna(mileage)),
+            # Discriminative-spec completeness (0–1) from predict_prices —
+            # decide() abstains below _MIN_SPEC_FILL (the model could only
+            # baseline-guess). None when the prediction carried no fill.
+            "spec_fill": gb_spec_fill.get(olx_id),
             "fuel_type": listing.get("fuel_type", ""),
             # LLM fields for display/warnings
             "desc_mentions_accident": bool(desc_mentions_accident) if pd.notna(desc_mentions_accident) else None,

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -100,6 +100,86 @@ def test_no_opinion_on_wide_band():
     assert any("band" in r for r in d.reasons)
 
 
+# ---- Missing-odometer penalty ---------------------------------------------
+
+
+def test_mileage_missing_pushes_band_into_no_opinion():
+    """Reproduction of the 2026-06-08 Mégane case: a would-be BUY (ask far
+    under an inflated prediction, band just under the WIDE gate) loses its
+    verdict once the odometer is flagged missing — the band is widened past
+    the gate."""
+    healthy = decide(
+        _row(price_eur=8300, predicted_price=17457,
+             fair_price_low=10950, fair_price_high=17789, band_pct=39.2),
+        _ctx(calibration_resid_pct={}),
+    )
+    assert healthy.verdict == VERDICT_BUY  # without the flag it's a (phantom) BUY
+
+    missing = decide(
+        _row(price_eur=8300, predicted_price=17457,
+             fair_price_low=10950, fair_price_high=17789, band_pct=39.2,
+             mileage_missing=True),
+        _ctx(calibration_resid_pct={}),
+    )
+    assert missing.verdict == VERDICT_NO_OPINION
+    assert any("odometer" in r for r in missing.reasons)
+
+
+def test_mileage_missing_inferred_from_nan_mileage_km():
+    """A present-but-NaN mileage_km is treated the same as the explicit flag."""
+    d = decide(
+        _row(price_eur=8300, predicted_price=17457,
+             fair_price_low=10950, fair_price_high=17789, band_pct=39.2,
+             mileage_km=float("nan")),
+        _ctx(calibration_resid_pct={}),
+    )
+    assert d.verdict == VERDICT_NO_OPINION
+
+
+def test_present_mileage_is_not_penalised():
+    """A healthy BUY with mileage present stays BUY — no penalty leaks in."""
+    d = decide(_row(price_eur=8500, predicted_price=13000, mileage_km=90000), _ctx())
+    assert d.verdict == VERDICT_BUY
+    assert "mileage_missing" not in d.components
+
+
+def test_mileage_missing_confidence_cut_without_band():
+    """When no band shipped the widening is a no-op, so the confidence
+    multiplier must still bite (penalty can't be bypassed by a missing band)."""
+    base = decide(_row(price_eur=8500, predicted_price=13000, band_pct=None), _ctx())
+    missing = decide(
+        _row(price_eur=8500, predicted_price=13000, band_pct=None,
+             mileage_missing=True),
+        _ctx(),
+    )
+    assert missing.components["confidence"] < base.components["confidence"]
+    assert missing.score < base.score
+
+
+def test_low_spec_fill_triggers_penalty_even_with_mileage_present():
+    """A stripped listing (only 1 of 4 specs) is abstained on even when the
+    odometer itself is present — the spec-fill trigger, not just mileage."""
+    d = decide(
+        _row(price_eur=8300, predicted_price=17457,
+             fair_price_low=10950, fair_price_high=17789, band_pct=39.2,
+             mileage_km=120000, spec_fill=0.25),
+        _ctx(calibration_resid_pct={}),
+    )
+    assert d.verdict == VERDICT_NO_OPINION
+    assert any("specs" in r for r in d.reasons)
+    assert d.components["spec_fill"] == 0.25
+
+
+def test_adequate_spec_fill_is_not_penalised():
+    """spec_fill at/above the threshold leaves a healthy BUY intact."""
+    d = decide(
+        _row(price_eur=8500, predicted_price=13000, mileage_km=90000, spec_fill=0.75),
+        _ctx(),
+    )
+    assert d.verdict == VERDICT_BUY
+    assert "spec_fill" not in d.components  # only recorded when it triggers
+
+
 # ---- Step 5 economics -----------------------------------------------------
 
 


### PR DESCRIPTION
## What

Fixes **phantom BUY deals** on listings missing discriminative specs (mileage / hp / engine / fuel). Root cause + two-part fix from the 2026-06-08 audit (`project_missing_feature_overprediction`).

**Symptom:** Renault Mégane (olx_id `JpGdX`, €8.3k, no mileage/engine/fuel/hp) scored **BUY 46.5**. Systemic: ~**33%** of stripped-holdout rows looked like 30%+ deals.

**Root cause (measured):** the model leans ~70% on coarse group features (`enc_plat` alone = 54% of median-model gain). With per-car specs absent it collapses to the brand+generation+year baseline and **over-predicts behind a deceptively tight CQR band** (NaN branches under-trained on ~97% full-feature data). With mileage present it's well-calibrated (P50/ask 0.95) — the defect lives entirely in the missing-feature rows (1.87).

### Fix 1 — abstention in `decide()` (safety net)
Low-feature gate widens `band_frac` +0.12 (borderline rows cross `_BAND_WIDE` → NO_OPINION) and cuts confidence ×0.55, triggered by a **missing odometer OR `spec_fill` < 0.5**. `spec_fill` (fraction of `{mileage_km, horsepower, engine_cc, fuel_type}` present) emitted by `predict_prices`, threaded via `compute_signals`. A `_has` probe keeps present-but-NaN distinct from column-absent. Mégane → **NO_OPINION** (band 39.2%→51.2%).

### Fix 2 — missingness-aware training (the cure)
`_apply_spec_dropout` NaNs k∈{1..4} random specs on **25%** of FITTING rows only (each CV fold + final fit, **after** `enc_plat` OOF which is keyed on brand|generation and untouched; val/OOF/calibration rows keep real features so MAPE + conformal q stay honest). The low/high CQR heads learn to **widen** on absent specs instead of baselining tight. Holdout + bootstrap validated (`scripts/exp_feature_dropout.py`, frac=0.25 sweet spot): stripped-row phantom-deal rate **34-41%→~16%**, coverage **70%→~80%** restored, ~**zero** full-feature cost (MAPE Δ +0.02 [-0.21,+0.28]), robust across seeds 42 & 7.

## Deploy
**No schema bump** — no new model feature (`spec_fill` is an output column; dropout is train-time) → `_ALL_FEATURES` unchanged → stays **v12**, pure retrain. Same flow as #10: merge → scrape retrains + rebuilds witnesses; the abstention activates once `predict_prices` emits `spec_fill`.

97 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
