### PR TITLE
decision: cheap-tail value-trust guard + condition-NLP fault detector

### DIFF
--- a/src/analytics/condition_signal.py
+++ b/src/analytics/condition_signal.py
@@ -1,0 +1,103 @@
+"""Condition NLP: disclosed minor mechanical faults a spec-only model can't see.
+
+The 2026-06-25 cheap-tail audit (50 blind live-OLX appraisals + 12.8k-car
+population pass) found the price model is condition-blind: it predicts ≈ the
+comparable median and ignores faults disclosed in the listing text. A
+``check-engine`` light, a ``catalisador a precisar`` or a ``precisa de
+reparação`` lands at ``damage_severity == 1`` (normal wear) today, so the model
+over-prices it — and these concentrate in the <€4k tail where a €300-800 fault
+is a large fraction of the car's value.
+
+This module is the missing tier *between* normal wear and the severity-3 hard
+blocks in :mod:`src.parser.llm_enrichment` (parts-only / non-runner / severe
+mechanical). It does NOT block the deal — the car runs — it translates a
+disclosed fault into a repair provision the deal scorer subtracts from net
+margin (:func:`src.analytics.decision.decide` step 5b). Deliberately
+precision-biased: a false positive only makes the scorer more cautious, which
+matches the project's "quality over coverage" stance.
+"""
+
+import re
+
+# Unambiguous "runs but has a disclosed fault" phrases. Salvage / non-runner /
+# severe-mechanical phrasings are intentionally NOT here — those hit the
+# severity-3 hard blocks upstream. Each alternative is written to be self-
+# evidently a fault so the negation surface is small.
+_FAULT_PHRASES = [
+    # dashboard warning light ON (guard against "apagada/desligada/sem")
+    r"(?<!sem\s)luz\s+(?:da\s+|de\s+|do\s+)?"
+    r"(?:inje[çc][ãa]o|avarias?|motor|airbag|abs|esp)\b"
+    r"(?!\s*(?:apagad|desligad|off))",
+    r"check\s*engine",
+    r"avaria\s+(?:el[ée]tr[óo]nica|electr[óo]nica|el[ée]ctrica)",
+    # catalisador / DPF / EGR / turbo issues (lighter than 'fundido' = severe)
+    r"catalisador\s+(?:avariad|fundid|partid|roubad|cortad|a\s+precisar|"
+    r"para\s+(?:trocar|substituir)|estragad)",
+    r"(?:fap|dpf)\s+(?:entupid|avariad|a\s+precisar)",
+    r"v[áa]lvula\s+egr\s+(?:avariad|entupid|a\s+precisar)",
+    r"turbo\s+(?:a\s+precisar|a\s+apitar|com\s+folga|avariad|fundid)",
+    # clutch / gearbox slipping (not 'avariada' = severe)
+    r"embra(?:i|e)agem\s+(?:gasta|a\s+patinar|a\s+precisar|"
+    r"para\s+(?:trocar|substituir))",
+    # smoke / overheat / leaks
+    r"(?:deita|deitar|a\s+deitar)\s+fumo",
+    r"sobreaquec",
+    r"(?:fuga|perde|perda|queima)\s+(?:de\s+)?[óo]leo",
+    # failed / pending inspection
+    r"(?:reprovad[oa]|chumb(?:ou|ado))\s+(?:na|em|à)?\s*inspe[çc][ãa]o",
+    r"inspe[çc][ãa]o\s+(?:reprovad|com\s+(?:defeitos|anomalias))",
+]
+_FAULT_PATTERN = re.compile("|".join(_FAULT_PHRASES), re.IGNORECASE)
+
+# "needs repair / work" family — guarded against immediate negation
+# ("não precisa de …", "sem precisar de …"). Fixed-width lookbehind only, so
+# the guard catches the common direct-negation cases.
+_NEEDS_REPAIR_PATTERN = re.compile(
+    r"(?<!n[ãa]o\s)(?<!sem\s)"
+    r"(?:precisa|necessita|a\s+precisar)\s+de\s+"
+    r"(?:uma?\s+|alguns?\s+|pequen[oa]s?\s+|alguma\s+)?"
+    r"(?:repara[çc][ãa]o|repara[çc][õo]es|arranjo|conserto|interven[çc][ãa]o|"
+    r"m[ãa]o\s+de\s+obra|mec[âa]nica|obras?\s+de\s+mec[âa]nica)",
+    re.IGNORECASE,
+)
+
+# Repair provision sizing. Floor covers a typical cat / sensor / clutch job;
+# the %-of-price term scales it on pricier cars; the cap and the half-the-car
+# guard keep it sane on both ends.
+_FAULT_COST_FLOOR = 400.0
+_FAULT_COST_PCT = 0.18
+_FAULT_COST_CAP = 1500.0
+
+
+def detect_minor_fault(title: str | None, description: str | None) -> str | None:
+    """Return a short label for the first disclosed minor fault, else None."""
+    text = f"{title or ''} {description or ''}"
+    m = _FAULT_PATTERN.search(text)
+    if m:
+        return re.sub(r"\s+", " ", m.group(0)).strip().lower()[:60]
+    m = _NEEDS_REPAIR_PATTERN.search(text)
+    if m:
+        return re.sub(r"\s+", " ", m.group(0)).strip().lower()[:60]
+    return None
+
+
+def minor_fault_cost(
+    title: str | None, description: str | None, price
+) -> tuple[float, str | None]:
+    """Repair provision (€, ``flag``) for a disclosed minor fault.
+
+    Returns ``(0.0, None)`` when no fault phrase is present. The provision is
+    ``clamp(price * 0.18, 400, 1500)`` and never exceeds half the asking price.
+    """
+    flag = detect_minor_fault(title, description)
+    if not flag:
+        return 0.0, None
+    try:
+        p = float(price)
+    except (TypeError, ValueError):
+        p = 0.0
+    if p <= 0:
+        return _FAULT_COST_FLOOR, flag
+    cost = min(max(_FAULT_COST_FLOOR, p * _FAULT_COST_PCT), _FAULT_COST_CAP)
+    cost = min(cost, p * 0.5)
+    return round(cost, 0), flag

--- a/src/analytics/decision.py
+++ b/src/analytics/decision.py
@@ -29,6 +29,11 @@ from typing import Mapping
 import numpy as np
 import pandas as pd
 
+# Module-level (not lazy) so the stlite bundler's import tracer
+# (scripts/build_stlite_bundle.py walks only top-level imports) pulls
+# condition_signal.py into the browser bundle. It has no heavy deps (re only).
+from src.analytics.condition_signal import minor_fault_cost
+
 
 # Public types --------------------------------------------------------------
 
@@ -289,6 +294,21 @@ _HOLDING_COST_EUR_PER_DAY = 1.30
 _DEFAULT_HOLD_DAYS = 45
 _BUY_SCORE = 18.0
 _WATCH_SCORE = 15.0
+# Cheap-tail value-trust guard (2026-06-25 audit: 50 blind live-OLX appraisals
+# + 12.8k-car population pass). Below _CHEAP_TIER_EUR (asking) the spec-only
+# model predicts ≈ comp-median and is blind to condition; the asking price
+# (set by someone who saw the car) is a far better value anchor — model MAPE
+# 54% vs asking 17% on <€4k, and raw pred>ask "BUY" precision is ~9% there.
+# Two deal-conservative guards in step 4b:
+#   (a) divergence cap — a model value > _CHEAP_DIVERGENCE_CAP× ask in this
+#       tier is almost always a condition/bait artefact (C180 €875→pred €11.1k),
+#       not a deal → NO_OPINION.
+#   (b) asking blend — value := _CHEAP_PRED_W·model + (1−_CHEAP_PRED_W)·ask,
+#       the audit's "blend70" winner. Only ever shrinks a positive margin.
+# Set _CHEAP_PRED_W=1.0 and _CHEAP_DIVERGENCE_CAP=inf to disable.
+_CHEAP_TIER_EUR = 4000.0
+_CHEAP_PRED_W = 0.30
+_CHEAP_DIVERGENCE_CAP = 2.0
 # Low-feature-confidence penalty (audit 2026-06-08). When the
 # discriminative per-car features are absent the price model collapses to a
 # coarse brand+generation+year baseline (enc_plat alone is 54% of model
@@ -518,6 +538,32 @@ def decide(
 
     components["predicted_corrected"] = round(predicted_corrected, 0)
 
+    # ---- Step 4b: cheap-tail value-trust guard (2026-06-25 cheap-tail audit).
+    # See the _CHEAP_* tunables. The spec-only model can't see condition in the
+    # <€4k tail, where it predicts ≈ comp-median and the asking price is the
+    # better anchor. (a) implausible model/ask divergence → abstain; (b) blend
+    # the value estimate toward asking. Both purely reduce BUY propensity here.
+    if 0 < price < _CHEAP_TIER_EUR:
+        if predicted_corrected > price * _CHEAP_DIVERGENCE_CAP:
+            ratio = predicted_corrected / price
+            components["cheap_divergence_ratio"] = round(ratio, 2)
+            reasons.append(
+                f"cheap tier (<€{_CHEAP_TIER_EUR:,.0f}): model value {ratio:.1f}× "
+                "ask — implausible, spec model is blind to condition here"
+            )
+            return Decision(VERDICT_NO_OPINION, 0.0, reasons, components)
+        if predicted_corrected > price:
+            predicted_corrected = (
+                _CHEAP_PRED_W * predicted_corrected + (1.0 - _CHEAP_PRED_W) * price
+            )
+            components["cheap_blend_applied"] = True
+            components["predicted_corrected"] = round(predicted_corrected, 0)
+            reasons.append(
+                f"cheap tier (<€{_CHEAP_TIER_EUR:,.0f}): value blended "
+                f"{int(_CHEAP_PRED_W * 100)}% model / "
+                f"{int((1 - _CHEAP_PRED_W) * 100)}% ask — condition-blind here"
+            )
+
     # ---- Step 5: net margin after repair + fees.
     # Look up DoM here (the gate at step 8 reuses it) so the holding-cost
     # component of fees is segment-aware rather than a flat stub.
@@ -546,6 +592,20 @@ def decide(
                 isv_eur = float(res["isv_eur"])
     except Exception:  # noqa: BLE001 — ISV is best-effort; never break a verdict
         isv_eur = 0.0
+
+    # ---- Step 5b: condition NLP — disclosed minor faults (2026-06-25 audit).
+    # The spec-only model can't see "check-engine on / catalisador a precisar /
+    # precisa de reparação" — these land at damage_severity 1 (normal wear) yet
+    # are real €-costs that erase a thin flip margin. Reads title+desc (carried
+    # via Recommendations _extra_cols); never blocks a verdict. Adds to
+    # repair_cost so it flows through net margin.
+    fault_cost, fault_flag = minor_fault_cost(
+        g("title") or "", g("description") or "", price)
+    if fault_cost > 0:
+        repair_cost += fault_cost
+        components["condition_fault_cost_eur"] = round(fault_cost, 0)
+        components["condition_fault"] = fault_flag
+        reasons.append(f"−€{fault_cost:.0f} disclosed fault ({fault_flag})")
 
     net_margin = raw_margin - repair_cost - fees - isv_eur
     net_margin_pct = (net_margin / predicted_corrected) * 100 if predicted_corrected else 0.0

--- a/src/dashboard/🔥_Recommendations.py
+++ b/src/dashboard/🔥_Recommendations.py
@@ -326,6 +326,10 @@ deals["est_roi_pct"] = ((deals["predicted_price"] - deals["price_eur"]) / _price
 _extra_cols = [
     "urgency", "warranty", "first_owner_selling", "taxi_fleet_rental",
     "days_listed", "price_change_eur", "mechanical_condition",
+    # title + description carry the raw text decide() scans for ISV import
+    # flags and the condition-NLP minor-fault detector (2026-06-25 audit).
+    # Without them both scans are inert on the feed.
+    "title", "description",
 ]
 _present = [c for c in _extra_cols if c in listings_df.columns]
 if _present:

--- a/tests/test_condition_signal.py
+++ b/tests/test_condition_signal.py
@@ -1,0 +1,52 @@
+"""Tests for the condition-NLP minor-fault detector (2026-06-25 cheap-tail audit)."""
+
+import pytest
+
+from src.analytics.condition_signal import detect_minor_fault, minor_fault_cost
+
+
+@pytest.mark.parametrize("text", [
+    "Carro impecável, luz da injeção acesa no painel",
+    "tudo ok mas tem o check engine ligado",
+    "catalisador a precisar de substituição",
+    "embraiagem a patinar em subida",
+    "deita fumo branco no arranque",
+    "reprovado na inspeção por emissões",
+    "precisa de reparação na caixa",
+    "necessita de mão de obra mecânica",
+    "tem fuga de óleo no motor",
+    "avaria eletrónica intermitente",
+])
+def test_detects_minor_faults(text):
+    assert detect_minor_fault("", text) is not None
+
+
+@pytest.mark.parametrize("text", [
+    "Carro impecável, sempre na marca, full extras",
+    "não precisa de qualquer reparação, está perfeito",
+    "sem qualquer avaria, motor impecável",
+    "luz de avaria apagada, tudo a funcionar",
+    "revisão feita, distribuição nova, pronto a andar",
+])
+def test_clean_or_negated_text_no_fault(text):
+    assert detect_minor_fault("Volkswagen Golf 1.6 TDI", text) is None
+
+
+def test_cost_clamps_and_scales():
+    # below floor -> floor
+    cost, flag = minor_fault_cost("", "catalisador avariado", 1500)
+    assert flag is not None and cost == 400        # 0.18*1500=270 -> floored to 400
+    # mid -> %-of-price
+    cost, _ = minor_fault_cost("", "check engine", 5000)
+    assert cost == 900                              # 0.18*5000
+    # cap
+    cost, _ = minor_fault_cost("", "check engine", 50000)
+    assert cost == 1500                             # capped
+    # never exceeds half the car
+    cost, _ = minor_fault_cost("", "catalisador a precisar", 600)
+    assert cost == 300                              # min(max(400,108),1500)=400 -> min(400, 300)=300
+
+
+def test_no_fault_zero_cost():
+    cost, flag = minor_fault_cost("Audi A4", "estado impecável, full extras", 4000)
+    assert cost == 0.0 and flag is None

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -391,3 +391,72 @@ def test_build_context_extracts_dom_from_sold():
     assert 25 <= ctx.dom_median[key] <= 28
     # 1 of 2 sold within 21d → 0.5
     assert ctx.dom_fast_share[key] == pytest.approx(0.5)
+
+
+# ---- Cheap-tail value-trust guard + condition NLP (2026-06-25 audit) -------
+
+import src.analytics.decision as _decision_mod  # noqa: E402
+
+
+def _cheap_ctx() -> DecisionContext:
+    """Neutral ctx — empty segment maps so the cheap guard is isolated."""
+    return DecisionContext(coverage_80=0.81)
+
+
+def _cheap_row(**kw) -> pd.Series:
+    base = {
+        "brand": "Citroen", "model": "C3", "generation": None,
+        "price_eur": 2800.0, "predicted_price": 3517.0,
+        "fair_price_low": 2000.0, "fair_price_high": 4000.0,
+        "sample_size": 12, "band_pct": 20.0, "damage_severity": 0,
+        "desc_mentions_accident": False, "right_hand_drive": False,
+        "days_listed": 10, "price_change_eur": 0,
+        "title": "Citroen C3", "description": "carro de familia, bom estado",
+    }
+    base.update(kw)
+    return _row(**base)
+
+
+def test_cheap_blend_suppresses_marginal_phantom(monkeypatch):
+    # ask 2800 / model 3517 (1.26x) clears the margin floor WITHOUT the guard.
+    monkeypatch.setattr(_decision_mod, "_CHEAP_PRED_W", 1.0)
+    monkeypatch.setattr(_decision_mod, "_CHEAP_DIVERGENCE_CAP", 1e9)
+    off = decide(_cheap_row(), _cheap_ctx())
+    assert off.verdict in (VERDICT_BUY, VERDICT_WATCH)
+    # With the guard at the shipped weight (0.30 model / 0.70 ask) the blended
+    # value collapses the margin below the 12% floor -> SKIP.
+    monkeypatch.setattr(_decision_mod, "_CHEAP_PRED_W", 0.30)
+    monkeypatch.setattr(_decision_mod, "_CHEAP_DIVERGENCE_CAP", 2.0)
+    on = decide(_cheap_row(), _cheap_ctx())
+    assert on.verdict == VERDICT_SKIP
+    assert any("cheap tier" in r and "blended" in r for r in on.reasons)
+
+
+def test_cheap_divergence_cap_abstains():
+    # C180-class: ask 875 / model 11131 = 12.7x ask -> untrustworthy -> abstain.
+    d = decide(_cheap_row(price_eur=875.0, predicted_price=11131.0,
+                          fair_price_low=6000.0, fair_price_high=14000.0,
+                          band_pct=30.0), _cheap_ctx())
+    assert d.verdict == VERDICT_NO_OPINION
+    assert any("ask" in r and "implausible" in r for r in d.reasons)
+
+
+def test_cheap_guard_not_applied_above_tier():
+    # >= 4000 ask: the healthy mid-market baseline must be untouched.
+    d = decide(_row(), _ctx())
+    assert d.verdict in (VERDICT_BUY, VERDICT_WATCH)
+    assert not any("cheap tier" in r for r in d.reasons)
+
+
+def test_condition_fault_cost_reduces_margin(monkeypatch):
+    # Disable the blend so we isolate the fault-cost effect; a disclosed
+    # check-engine fault subtracts a repair provision -> reason recorded.
+    monkeypatch.setattr(_decision_mod, "_CHEAP_PRED_W", 1.0)
+    monkeypatch.setattr(_decision_mod, "_CHEAP_DIVERGENCE_CAP", 1e9)
+    clean = decide(_cheap_row(description="bom estado, sempre na marca"), _cheap_ctx())
+    faulty = decide(_cheap_row(description="luz da injeção acesa, catalisador a precisar"),
+                    _cheap_ctx())
+    assert faulty.components.get("condition_fault_cost_eur", 0) > 0
+    assert any("disclosed fault" in r for r in faulty.reasons)
+    # the fault provision lowers the score vs the clean twin
+    assert faulty.score <= clean.score


### PR DESCRIPTION
## What

Implements the fix from the 2026-06-25 **cheap-tail audit** (50 blind live-OLX expert appraisals + a 12.8k-car population pass). The price model is **condition-blind** and over-predicts the **<€4k tail**: it predicts ≈ comparable-median and ignores faults disclosed in the listing text. There, raw `pred>ask` "BUY" precision is **~9%** and the asking price beats the model (value MAPE **17% vs 54%**). Production currently surfaces ~10 such cheap "deals".

## Changes

- **`decision.py` step 4b — cheap-tier value-trust guard** (asking `<€4000`):
  - divergence cap: model value `> 2× ask` → `NO_OPINION` (e.g. C180 €875 → pred €11.1k);
  - else blend value `0.30·model + 0.70·ask`. Only ever **shrinks** a positive margin; **mid/premium (≥€4k) untouched**.
  - Validation: removes **8–9 of the 10** cheap deals production currently surfaces (Mini 3P @ 2.43× ask → divergence; rest blend below the 12% net-margin floor).
- **`src/analytics/condition_signal.py` (new) — condition NLP**: detects disclosed minor faults (check-engine, `catalisador a precisar`, `precisa de reparação`, `fuga de óleo`, failed inspection…) with negation guards → repair provision `clamp(0.18·price, 400, 1500)`; wired into `decision.py` step 5b.
- **`Recommendations.py` `_extra_cols` += `title`/`description`** so `decide()` can scan them — both the condition-NLP **and the existing ISV scan** were inert on the feed without this.
- `condition_signal` imported at **module level** in `decision.py` so the stlite bundler's top-level import tracer ships it into the browser bundle (verified: appears in `build_stlite_bundle.py` output).

## Trade-off (intentional)

On the real engine the blend ≈ **near-total cheap-tier suppression**, because genuine cheap deals and phantoms have ~identical `pred/ask` ratios (can't separate without condition data — the audit's core finding). This is the precision-max / "quality over coverage" choice. Tunable via `_CHEAP_TIER_EUR` / `_CHEAP_PRED_W` / `_CHEAP_DIVERGENCE_CAP`.

## Tests

New `test_condition_signal.py` + cheap-guard/divergence/fault cases in `test_decision.py`. Full suite **640 passed** (only the 2 `test_ollama_integration` network tests fail — environmental). Bundler verified to include `condition_signal.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)