### PR TITLE
ci: decouple Scrape from LLM smoke test (unblock stale scraping)

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -225,11 +225,14 @@ jobs:
         # overlap during fan-out. Runs only here on the self-hosted Mac
         # (where Ollama lives); the GitHub-hosted Ubuntu Tests job filters
         # smoke out via -m "not smoke".
-        # Fails fast: if the local Ollama or routing layer is broken there's
-        # no point burning 2 h on Scrape + Enrich. The earlier diagnostic
-        # step (above) is already in the log to root-cause from.
+        # Health signal for the two-backend pool — it NO LONGER gates Scrape
+        # (that step now runs on !cancelled()), so a slow-backend flake here
+        # surfaces as a red check without starving data collection. The
+        # earlier diagnostic step (above) is already in the log to root-cause
+        # from. 12 min ceiling leaves room for a cold model-load on the .69
+        # box during warm-up without SIGKILLing an otherwise-healthy run.
         if: env.WITH_LLM == 'true'
-        timeout-minutes: 5
+        timeout-minutes: 12
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
@@ -237,6 +240,15 @@ jobs:
           .venv/bin/pytest tests/test_ollama_integration.py -m smoke -v --tb=short
 
       - name: Scrape
+        # Decoupled from the LLM smoke step. A flake in the Ollama pool
+        # (e.g. a slow cold model-load on the .69 box tripping the
+        # concurrent-inference smoke test) previously left this step on the
+        # default if:success(), which silently SKIPPED scraping for days
+        # while enrich/train/upload kept re-shipping stale data. Scrape
+        # auto-falls back to raw-only when Ollama is unreachable, so running
+        # unconditionally is safe; a genuinely-broken local Ollama is still
+        # caught by the hard-exit in "Ensure Ollama is running".
+        if: ${{ !cancelled() }}
         env:
           PYTHONPATH: ${{ github.workspace }}
         # Per-step timeout caps how long scrape can monopolise the budget.

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -235,9 +235,13 @@ def test_concurrent_inference_actually_uses_both_backends():
         "options": {"num_predict": 5, "temperature": 0.0},
     }
 
-    # Warm up both so cold model load doesn't pollute timings.
+    # Warm up both so cold model load doesn't pollute timings. The warm-up
+    # itself must tolerate a cold load — the .69 MX230 can take >120s to page
+    # qwen3:4b in under VRAM pressure, and a warm-up timeout there is a false
+    # failure, not a pool defect. The *timed* calls below stay at 120s
+    # (backends are warm by then; a warm call over 120s IS a real problem).
     for url in healthy:
-        httpx.post(f"{url.rstrip('/')}/api/generate", json=payload, timeout=120)
+        httpx.post(f"{url.rstrip('/')}/api/generate", json=payload, timeout=300)
 
     def _timed_call(url: str) -> tuple[str, float, float]:
         """Return (url, start_ts, finish_ts) for overlap analysis."""


### PR DESCRIPTION
## Problem
Every scheduled `Scrape OLX` run has been **red since ~2026-07-13** and, more importantly, **not scraping**:

- `MAX(last_scraped_at) = 2026-07-13 14:56`, `scraped last 24h = 0`, `new listings 24h = 0`.
- enrich/train/upload kept running on stale data and re-shipping the `latest-data` release each cron → the outage was **invisible from the release timestamps**.

## Root cause
1. `Run Ollama smoke tests` exits 1 when `test_concurrent_inference_actually_uses_both_backends` times out.
2. The `Scrape` step carried the **default `if: success()`**, so that smoke failure **skipped scraping entirely**.
3. The smoke failure itself is a **false positive**: the test's warm-up `httpx.post` used `timeout=120`, but the `.69` MX230 box can take >120s to page `qwen3:4b` in under VRAM pressure. Both backends are live and the real `Enrich with LLM` step succeeds.

## Fix
- **Scrape → `if: ${{ !cancelled() }}`** so an LLM-pool flake can't starve data collection (scrape auto-falls back to raw-only when Ollama is down; genuinely-broken local Ollama is still caught by `Ensure Ollama is running`). The smoke test stays in the smoke set as a real pool-health signal — it just no longer gates scraping.
- **Warm-up timeout `120 → 300`** to absorb a cold model-load. The *timed* concurrency calls stay at 120s, so a warm call >120s still fails (diagnostic preserved).
- **Smoke step `timeout-minutes 5 → 12`** for cold-load headroom.

## Verified
- Both Ollama backends live now: `.77` localhost (`qwen3:4b-instruct`, `qwen2.5vl:3b`), `.69` (`qwen3:4b-instruct`); `.69` warm latency ~8s.
- `yaml.safe_load` OK, test compiles.

## Out of scope (flagged separately)
- Telegram alerts failing `401 Unauthorized` (expired bot token) — needs a token refresh, not a code change.
- `Backfill seller profiles` hitting its 15-min `timeout-minutes` each run (has `continue-on-error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)