### PR TITLE
alerts: move Telegram bot token to GitHub secret (fix 401 alerts)

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -381,6 +381,7 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           PYTHONPATH: ${{ github.workspace }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         # Internal retry envelope is ~8 min (src/alerts/telegram_bot.py
         # _REFRESH_RETRY_*), sized to outlast the scrape worker's 3-5 min
         # market_stats lock. Step timeout must exceed that envelope with

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -76,7 +76,12 @@ llm:
   num_ctx: 2048
 
 alerts:
-  telegram_bot_token: "8651422044:AAEf93eodK6d4F7fn1FVH-vh0H5JX-gb92s"
+  # Bot token is NOT stored here — it lives in the GitHub Actions secret
+  # TELEGRAM_BOT_TOKEN, injected as env into the "Send Telegram alerts" step.
+  # telegram_bot.py reads env first, this key second (_load_config). Kept
+  # empty so a revoked token can't linger in git history. For local runs,
+  # `export TELEGRAM_BOT_TOKEN=...` in your shell.
+  telegram_bot_token: ""
   telegram_chat_id: "604665081"
   min_discount_pct: 15
   state_file: "data/alerts_state.json"


### PR DESCRIPTION
## Problem
Scheduled runs spammed `Telegram API error: 401 Unauthorized` and delivered **zero deal alerts**. The bot token was committed in plaintext (`config/settings.yaml`) and had gone dead. The old bot (`id 8651422044`) was unrecoverable — even a freshly-revoked token 401'd and the username stopped resolving.

## Fix
- New bot **@BuyCarPortugalBot** (`id 8952795220`) created; token verified live (`getMe` → `ok:true`).
- Token stored in GitHub Actions secret **`TELEGRAM_BOT_TOKEN`**, injected as env into the `Send Telegram alerts` step. `telegram_bot.py` already reads env before config (`_load_config`), so no code change.
- `telegram_bot_token` in `settings.yaml` emptied (pointer comment left) so no token lives in git.

## Remaining (manual, one tap)
Delivery to the DM `chat_id 604665081` needs that user to **/start** the new bot once (bots can't initiate DMs — `sendMessage` returned `chat not found` until then). Verified out-of-band after /start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)