### PR TITLE
seller-backfill: bound per-run work + staleness ordering, TTL 30

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -297,23 +297,27 @@ jobs:
       - name: Backfill seller profiles
         # Resolves seller_uuid for newly-scraped listings (which only have
         # seller_profile_url at this point) and refreshes any seller row
-        # whose profile_fetched_at is older than 14 days. Steady state
-        # after the initial 1278-profile bootstrap: ~10-50 new profiles
-        # per cron + a slow trickle of refreshes. Cheap (~1s/profile via
-        # OlxScraper's throttle-aware client) so 15-min timeout has wide
-        # headroom.
+        # whose profile_fetched_at is older than --ttl-days (30). The ~15k
+        # seller population was bootstrapped in bursts, so a 14-day TTL made
+        # whole cohorts re-mature on the same day (e.g. one 5.7k-profile
+        # day), flooding a single cron with far more than the ~1100 fetches
+        # a 15-min step can do at ~0.8s each — so it timed out every peak
+        # day. Fix: --limit 900 bounds each run (~12 min, never times out),
+        # the selector orders by staleness (oldest/unlinked first), and the
+        # resumable query drains the rest across the day's crons (~5k/day
+        # capacity >> ~500/day arrival at TTL 30). continue-on-error keeps a
+        # flaky OLX day from failing the run either way.
         #
         # Must run before train-model so seller_listings_count_90d /
         # seller_pseudoprivate / seller_cars_count are populated when the
-        # price model rebuilds. continue-on-error: a flaky OLX day
-        # shouldn't block the rest of the cron.
+        # price model rebuilds.
         if: ${{ !cancelled() }}
         env:
           PYTHONPATH: ${{ github.workspace }}
         timeout-minutes: 15
         continue-on-error: true
         run: |
-          .venv/bin/python -m scripts.backfill_sellers --ttl-days 14 --progress-every 100
+          .venv/bin/python -m scripts.backfill_sellers --ttl-days 30 --limit 900 --progress-every 100
 
       - name: Verify photos with damage classifier
         # Runs the v2 ResNet50 classifier on listings' photos and stores

--- a/scripts/backfill_sellers.py
+++ b/scripts/backfill_sellers.py
@@ -97,13 +97,20 @@ def _select_targets(
 
     De-dup at the SQL layer so a 256-ad dealer turns into one fetch,
     not 256.
+
+    Ordered by urgency, not alphabetically: first-pass URLs (no seller
+    row yet, so ``profile_fetched_at`` is NULL, coalesced to '') sort
+    first, then the stalest refreshes oldest-first. Paired with
+    ``--limit`` this makes a capped run spend its budget on the URLs that
+    need it most, and the resumable selector drains the remainder on
+    later crons instead of starving the same tail every time.
     """
     cutoff = (
         datetime.now(timezone.utc).replace(tzinfo=None)
         - timedelta(days=ttl_days)
     ).isoformat(sep=" ")
     sql = """
-        SELECT DISTINCT l.seller_profile_url
+        SELECT l.seller_profile_url
         FROM listings l
         LEFT JOIN sellers s ON s.uuid = l.seller_uuid
         WHERE l.seller_profile_url IS NOT NULL
@@ -112,7 +119,8 @@ def _select_targets(
             OR s.profile_fetched_at IS NULL
             OR s.profile_fetched_at < ?
           )
-        ORDER BY l.seller_profile_url
+        GROUP BY l.seller_profile_url
+        ORDER BY MIN(COALESCE(s.profile_fetched_at, '')) ASC
     """
     if limit is not None:
         sql += f" LIMIT {int(limit)}"


### PR DESCRIPTION
## Problem
`Backfill seller profiles` hit its 15-min `timeout-minutes` on peak days. Not a slowness bug — **lumpy re-maturation**: the ~15k seller population was bootstrapped in bursts, so a 14-day TTL made whole cohorts cross the staleness threshold on the same day (one cohort = **5.7k profiles**). A single cron then faced far more than the ~1100 fetches a 15-min step can do at ~0.8s each, and timed out ~26 short. `ORDER BY seller_profile_url` (alphabetical) also spent the budget on the wrong URLs.

It's `continue-on-error`, so it never failed the run — but burned the full 15 min and could leave sellers stale for the price-model retrain on peak days.

## Evidence (live DB)
Daily refresh histogram showed bursts: `07-02: 1756`, `07-03: 1223`, `07-04: 1033`, **`07-10: 5752`**, then ~700–800/day. At TTL 14 the 07-10 cohort would all re-mature on 07-24 → a ~5.7k-target day into a ~1100-capacity step.

## Fix
- **Selector orders by urgency**: unlinked/first-pass URLs first (`profile_fetched_at` NULL → `''`), then stalest refreshes oldest-first — `GROUP BY … ORDER BY MIN(COALESCE(profile_fetched_at,''))`. (`DISTINCT` → `GROUP BY` so the aggregate is usable in ORDER BY deterministically.)
- **`--limit 900`** bounds each run (~12 min, never times out); the resumable selector drains the rest across the day's ~5–6 crons (~5k/day capacity ≫ arrival).
- **`--ttl-days 14 → 30`** halves churn and softens spikes. Seller facets drift slowly and the signal is marginal, so 30d is safe.

## Verified
Selector returns targets oldest-first (`2026-05-29`, `2026-06-02`, … at the head). At TTL 30 the immediate queue drops **1126 → 42** (big cohorts now re-mature in August, spread out and capped by `--limit`). YAML valid, script compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)