### PR TITLE
price-model: fix luxury-price ceiling — fixed [€300,€250k] training clip

### DIFF
--- a/src/analytics/price_model.py
+++ b/src/analytics/price_model.py
@@ -470,12 +470,43 @@ def _pinball_loss(y_true: np.ndarray, y_pred: np.ndarray, alpha: float) -> float
     return float(np.mean(np.maximum(alpha * diff, (alpha - 1) * diff)))
 
 
+# Fixed price sanity bounds for training-row inclusion. These REPLACE the
+# earlier [1st, 99th] percentile clip (schema ≤v13). The percentile clip
+# discarded the cheapest and priciest ~1% of cars, so the tree never trained
+# on the tails and developed a hard prediction FLOOR (~€1.5–2k) and CEILING
+# (~€50k) — a GBM cannot predict outside its training-target range, and log vs
+# raw target is a monotone relabel that cannot move either bound.
+#
+# Time-aware backtest on the 2026-07-17 corpus (61k rows, train ≤06-21 →
+# newest 20% test, scripts sweep in exp_relax_clip) — swapping the percentile
+# clip for these fixed bounds, everything else identical:
+#   • LUXURY ceiling fixed: >€50k median bias −21.9% → −6.2%, MAPE 26.2 → 19.1%,
+#     80% coverage 0.28 → 0.73  (the top ~1% >€76k the clip was cutting)
+#   • cheap tail improved: <€2k median bias +22.6% → +14.4%, MAPE −3.6pp
+#     (residual over-prediction is condition-blindness, not the clip — the
+#     cheap-tail abstain/blend fix still stacks on top)
+#   • €2–50k core unchanged (within-noise); overall R² 0.855 → 0.905
+# Only ~1.7% more rows admitted (the real tails); the €300 floor + 10× swing +
+# mileage-sanity steps still drop parts/scrap and data-entry noise (spot-check:
+# the re-admitted €300–650 band is 1990s runners, not junk).
+#
+# No bundle-shape change (features/target/CQR semantics identical), so
+# _SCHEMA_VERSION stays 13 — the currently-shipped bundle keeps loading; the
+# next scheduled retrain picks this up. The €250k ceiling still caps genuine
+# data-entry errors (corpus max was €284k).
+_PRICE_FLOOR_EUR = 300.0
+_PRICE_CEIL_EUR = 250_000.0
+
+
 def _filter_training_data(df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
     """Drop outliers that would poison the quantile targets.
 
     Returns (filtered_df, drop_stats) for logging.  Filters:
       1. Price that moved 10× in either direction (data-entry noise, wrong currency)
-      2. Prices outside [1st, 99th] percentile (heavy-tail clip)
+      2. Prices outside [€300, €250k] fixed bounds — parts/scrap floor + data-entry
+         ceiling. REPLACED the old 1st/99th percentile clip, which truncated the
+         cheap/luxury tails and gave the model a hard floor+ceiling; see
+         _PRICE_FLOOR_EUR / _PRICE_CEIL_EUR.
       3. km / max(age, 1) outside [500, 100 000] (implausible mileage)
     """
     start = len(df)
@@ -493,13 +524,13 @@ def _filter_training_data(df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
             out = out[~extreme.fillna(False)]
         stats["dropped_10x_swing"] = dropped
 
-    # 2. Price percentile clip
+    # 2. Fixed price sanity bounds (see _PRICE_FLOOR_EUR / _PRICE_CEIL_EUR).
+    # Fixed — not percentile — so the model trains on the real cheap/luxury
+    # tails instead of a truncated middle. Empty-safe (no quantile call).
     prices = pd.to_numeric(out["price_eur"], errors="coerce")
-    if len(prices) > 0:
-        low_p, high_p = prices.quantile([0.01, 0.99])
-        price_mask = (prices >= low_p) & (prices <= high_p)
-        stats["dropped_price_percentile"] = int((~price_mask.fillna(False)).sum())
-        out = out[price_mask.fillna(False)]
+    price_mask = (prices >= _PRICE_FLOOR_EUR) & (prices <= _PRICE_CEIL_EUR)
+    stats["dropped_price_bounds"] = int((~price_mask.fillna(False)).sum())
+    out = out[price_mask.fillna(False)]
 
     # 3. Mileage sanity (km per year of age)
     current_year = datetime.now(timezone.utc).year

--- a/tests/test_price_model.py
+++ b/tests/test_price_model.py
@@ -180,7 +180,12 @@ def test_uncertainty_bundle_trains_and_predicts_positive_q():
     completeness, LLM-flag count, description × photo interaction); the
     inference helper builds them from the raw DataFrame, so callers
     pass ``df`` and the prepared ``X_main`` array."""
-    df = _sample_listings(400, with_first_seen_at=True)
+    # 800 (not 400): the per-row uncertainty regressor is trained on half of
+    # the time-aware cal-set (~20% of rows), so 400 leaves it ~40 rows — too
+    # few to reliably find a split, making ``per_row_q.std() > 0`` knife-edge
+    # (it flips on tiny changes to the filtered row count). 800 gives the
+    # regressor enough cal data that the per-row property holds robustly.
+    df = _sample_listings(800, with_first_seen_at=True)
     result = train_price_model(df)
     assert result is not None
     _models, cat_maps, _metrics, _oof, _calib, uncertainty, *_imp = result
@@ -732,9 +737,9 @@ class TestSoldTargetAdjustment:
         assert "sold_inclusion" in metrics
         si = metrics["sold_inclusion"]
         assert si["sold_rows_used"] > 0
-        # ``_filter_training_data`` clips the 1st/99th percentiles, so a
-        # handful of the 100 actives may be filtered out — check the
-        # majority survived rather than the exact count.
+        # ``_filter_training_data`` drops rows outside [€300, €250k] + the
+        # mileage-sanity band, so a handful of the 100 actives may be filtered
+        # out — check the majority survived rather than the exact count.
         assert si["active_rows"] >= 90
 
 


### PR DESCRIPTION
## Fix the luxury-price ceiling (and cheap-tail over-prediction) — swap the training price clip

`_filter_training_data` clipped training prices to the **[1st, 99th] percentile**, discarding the cheapest and priciest ~1% of cars. A GBM can't predict outside its training-target range, and log-vs-raw target is a monotone relabel that can't move that bound — so the model developed a hard **floor (~€1.5–2k)** and **ceiling (~€50k)**. This swaps the percentile clip for **fixed [€300, €250k] bounds** so the tree actually trains on the tails. One-file change; the hygiene steps (10× swing, mileage sanity) are untouched.

### Why (independent audit + backtest)
A Claude Science audit of the Jul-17 corpus flagged the tails: **>€50k under-predicted −32%**, **<€2k over-predicted +33%**. (Its "train in log space" suggestion was a non-fix — the model is *already* `log_target: true`.) The real lever is the clip.

Time-aware forward split, Jul-17 corpus (61k rows, train ≤2026-06-21 → newest 20% test). Only the clip changed; log target / inverse-log weights / sold adjustment / spec-dropout / monotone median all identical. Baseline (current clip) reproduces the audit within noise (overall MAPE 26.9% vs 26.8%, bias −6.0% vs −7%, coverage 78.6% vs 78.1%):

| Segment | n | MAPE | Median bias | 80% coverage |
|---|---|---|---|---|
| **€50k+** | 158 | 26.2 → **19.1** | **−21.9% → −6.2%** | **0.28 → 0.73** |
| **€0.3–2k** | 1694 | 64.0 → **60.4** | **+22.6% → +14.4%** | 0.71 → 0.76 |
| €2–5k | 3195 | 28.6 → 28.9 | −4.4% → −5.2% | 0.82 → 0.81 |
| €5–10k | 3285 | 19.2 → 19.2 | −7.4% → −7.0% | 0.82 → 0.82 |
| €10–20k | 2207 | 14.8 → 14.7 | −9.6% → −9.2% | 0.79 → 0.80 |
| €20–50k | 1259 | 14.3 → 14.5 | −8.4% → −8.5% | 0.78 → 0.76 |
| **ALL** | 11798 | 26.9 → **26.4** | −6.0% → −5.9% | 0.786 → **0.795** |

Overall **R² 0.855 → 0.905**; prediction ceiling €222k → €248k, floor €602 → €430.

- **Luxury ceiling** is the headline: the [99%] clip was cutting the top ~1% (>€76k), so the model couldn't reach it. Removing it nearly closes the −22% under-prediction and lifts >€50k coverage from a broken 28% to 73%.
- **Cheap tail** improves (over-prediction cut by a third) but doesn't vanish — the residual +14% is condition-blindness, so the cheap-tier abstain/blend work still stacks on top.
- **€2–50k core** unchanged (within-noise), no regression where the model already works.
- Cost: **+807 rows (1.7%)** admitted — the real tails. Spot-check of the re-admitted €300–650 band = 1990s runners (Focus/Clio/Corsa/Golf), not parts.

### Notes
- **No schema bump** — bundle shape (features/target/CQR) is identical, so `_SCHEMA_VERSION` stays **13**; the shipped v13 bundle keeps loading and the next scheduled retrain picks this up (retrains deploy via cron, not dispatch).
- Log stat key `dropped_price_percentile` → `dropped_price_bounds` (no consumer asserts on it).
- Follow-ups (not in this PR): bootstrap/multi-fold CI on the €50k+ number (n=158 is thin), and the separate cheap-tier abstain/blend + condition-NLP line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
