### PR TITLE
Value-gated OpenRouter enrichment of top deals (free-tier)

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -25,6 +25,10 @@ on:
         description: "Deep sweep (no early-stop, walk all pages — refreshes prices on the stale tail)"
         type: boolean
         default: false
+      with_openrouter:
+        description: "Value-gated cloud LLM enrichment of top deals via a free OpenRouter model"
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -40,6 +44,12 @@ permissions:
 # Deep sweep fires on the dedicated 04:00 cron OR when manually requested.
 env:
   WITH_LLM: ${{ github.event_name == 'schedule' && 'false' || inputs.with_llm }}
+  # OpenRouter cloud enrichment is INDEPENDENT of the retired Ollama pool — it
+  # is a value-gated call to a free cloud model, so it runs on scheduled runs
+  # (default true on schedule, unlike WITH_LLM). Manual dispatch respects the
+  # with_openrouter input. The step itself no-ops when OPENROUTER_API_KEY is
+  # unset, so this being 'true' is harmless if the secret was never added.
+  WITH_OPENROUTER: ${{ github.event_name == 'schedule' && 'true' || inputs.with_openrouter }}
   IS_DEEP: ${{ github.event.schedule == '37 4 * * *' || inputs.deep == 'true' }}
   # The only HF Hub consumer in this pipeline is the CLIP exterior filter
   # (openai/clip-vit-base-patch32) loaded by the photo-verify steps. Its
@@ -507,6 +517,34 @@ jobs:
               sys.exit(1)
           print('load_model accepted the fresh bundle')
           "
+
+      - name: Value-gated OpenRouter enrichment (top deals)
+        # Cloud condition-NLP on the handful of genuinely-undervalued deals the
+        # fresh GBM model flags — INDEPENDENT of the retired Ollama pool (it's a
+        # free cloud call, so it runs on scheduled runs; gated on WITH_OPENROUTER
+        # which defaults true on schedule, NOT on WITH_LLM). Ranks all fresh
+        # listings by GBM undervaluation via the production deal funnel, sends
+        # only the top-K (bounded by a free-tier daily/per-run request budget in
+        # data/openrouter_budget.json) to a free OpenRouter model, and writes
+        # condition columns (desc_mentions_*, mechanical_condition, urgency,
+        # warranty, damage_severity) back to the DB. Placed AFTER train/verify
+        # (so a fair value exists to rank on) and BEFORE build-dashboard/hot_deals
+        # (so the new fields propagate into signals + decisions with no retrain).
+        # No-ops (exit 0) when the OPENROUTER_API_KEY secret is unset or the daily
+        # budget is spent, and `|| warn` keeps a genuine error non-fatal — the
+        # deal feed still builds from the raw pipeline either way.
+        if: ${{ !cancelled() && env.WITH_OPENROUTER == 'true' && steps.train_model.outputs.train_rc == '0' }}
+        timeout-minutes: 20
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          if [ -z "$OPENROUTER_API_KEY" ]; then
+            echo "::warning::OPENROUTER_API_KEY secret not set — skipping OpenRouter enrichment. Add it in repo Settings → Secrets and variables → Actions."
+            exit 0
+          fi
+          .venv/bin/python -m src.cli enrich-openrouter \
+            || echo "::warning::OpenRouter enrichment failed — non-fatal; deals still build from the raw pipeline"
 
       - name: Build dashboard witnesses
         # Bakes predict_prices / TreeSHAP / anomaly / hazard / signals into

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -75,6 +75,49 @@ llm:
   # longer needed.
   num_ctx: 2048
 
+openrouter:
+  # Cloud LLM enrichment for the TOP DEALS only (value-gated). The local
+  # Ollama pool was retired 2026-07-24; this recovers condition NLP on the
+  # handful of genuinely-undervalued listings the GBM flags each day, via a
+  # FREE OpenRouter model. The API key is NOT stored here — it lives in the
+  # GitHub Actions secret OPENROUTER_API_KEY, injected as env into the
+  # "Value-gated OpenRouter enrichment" step. src/parser/openrouter_enrichment
+  # reads os.environ["OPENROUTER_API_KEY"]; a missing key makes the step a
+  # warn-and-skip no-op (same convention as TELEGRAM_BOT_TOKEN / CF hook).
+  base_url: "https://openrouter.ai/api/v1"
+  # Free models only, tried in order as a fallback chain. Free models are
+  # frequently upstream-rate-limited (HTTP 429) → on 429 we advance to the
+  # next model. Shortlist validated 2026-07-24: gemma-4-26b-a4b returns clean
+  # JSON in ~8 s; gemma-4-31b 429s often; gpt-oss-20b is the last resort.
+  models:
+    - "google/gemma-4-26b-a4b-it:free"
+    - "google/gemma-4-31b-it:free"
+    - "openai/gpt-oss-20b:free"
+  temperature: 0.1
+  max_tokens: 500     # richer schema (base 3 fields + condition NLP + red_flags)
+  max_chars: 2500
+  timeout_seconds: 90
+  max_retries: 1      # per model, on 429 / 5xx before advancing the chain
+  referer: "https://olx-car-parser.permikov134.workers.dev"
+  title: "olx-car-parser"
+  # Free-tier daily ceiling is ~50 requests/day; stay under it. Budget is in
+  # REQUESTS (each POST counts, incl. 429-triggered fallback attempts), tracked
+  # per-UTC-day in the state file (auto-resets at midnight). Each listing is
+  # normally 1 request. per_run_request_cap spreads spend across the day's
+  # scheduled runs (5 shallow + 1 deep).
+  daily_request_budget: 40
+  per_run_request_cap: 12
+  budget_state_file: "data/openrouter_budget.json"
+  # Pre-LLM value gate — reproduces the non-LLM half of the deal funnel so we
+  # only pay for genuinely-undervalued listings. Applied on top of
+  # compute_signals (which already enforces band ≤ 0.40, net ≥ €500, 0<disc≤60%).
+  gate:
+    min_price_eur: 4000     # skip the condition-blind cheap tail (< €4k)
+    min_spec_fill: 0.5      # need ≥2 of 4 discriminative specs
+    max_band_pct: 0.40      # (informational; compute_signals already gates this)
+    min_discount_pct: 0.0   # undervaluation_pct is a percent (GBM discount)
+    max_discount_pct: 60.0
+
 alerts:
   # Bot token is NOT stored here — it lives in the GitHub Actions secret
   # TELEGRAM_BOT_TOKEN, injected as env into the "Send Telegram alerts" step.

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -97,7 +97,10 @@ openrouter:
   max_tokens: 500     # richer schema (base 3 fields + condition NLP + red_flags)
   max_chars: 2500
   timeout_seconds: 90
-  max_retries: 1      # per model, on 429 / 5xx before advancing the chain
+  max_retries: 0      # 0 = no same-model retry; a free-model 429 is upstream
+                      # congestion, so advance the fallback chain instead of
+                      # burning budget retrying the same (stuck) model.
+  retry_backoff_seconds: 1.0  # brief pause before trying the next model on 429/5xx
   referer: "https://olx-car-parser.permikov134.workers.dev"
   title: "olx-car-parser"
   # Free-tier daily ceiling is ~50 requests/day; stay under it. Budget is in

--- a/src/analytics/value_gate.py
+++ b/src/analytics/value_gate.py
@@ -1,0 +1,99 @@
+"""Pre-LLM value gate — pick the genuinely interesting listings to enrich.
+
+Free-tier OpenRouter can only afford ~40 listings/day, so we must spend those
+calls on the deals that matter. The GBM price model needs NO LLM input to
+estimate fair value (mileage/hp/cc/fuel/brand/model/year are structured scrape
+fields), so we can price every fresh listing *before* spending a cloud call
+and rank by undervaluation.
+
+Rather than re-implement the deal funnel, this reuses the exact production
+path — ``compute_signals`` — which already materialises the deal feed with the
+band-width, GBM-discount and net-profit gates applied. We then take the top-K
+of that feed by GBM discount, excluding the cheap tier (where the model is
+condition-blind and over-predicts) and low-spec rows, and excluding anything
+already enriched. See the cheap-tail audit in project memory for why the
+€4k / spec_fill / band filters matter.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def rank_deal_olx_ids(
+    session,
+    *,
+    gate: dict,
+    limit: int,
+    exclude_ids: set[str] | frozenset[str] = frozenset(),
+) -> list[str]:
+    """Return up to ``limit`` olx_ids of the most-undervalued current deals.
+
+    Ranking = GBM ``undervaluation_pct`` descending over the production
+    ``compute_signals`` deal feed (which already enforces band_pct ≤ 0.40,
+    net-profit ≥ €500 and 0 < discount ≤ 60% internally). This adds:
+      * ``price_eur >= gate['min_price_eur']`` — skip the condition-blind cheap
+        tail where the model over-predicts phantom bargains.
+      * ``spec_fill >= gate['min_spec_fill']`` — need ≥2 of 4 discriminative
+        specs, else the fair value is a coarse baseline guess.
+      * exclude ``exclude_ids`` — listings already OpenRouter-enriched.
+
+    Returns [] (never raises) when there is no fresh model / no signals.
+    """
+    if limit <= 0:
+        return []
+
+    # Imported lazily — loading the analytics stack (LightGBM/sklearn) is
+    # expensive and pointless if the caller bailed on budget/secret first.
+    from src.storage.repository import get_listings_df, get_price_history_df
+    from src.analytics.computed_columns import enrich_listings
+    from src.analytics.turnover import compute_turnover_stats
+    from src.parser.llm_enrichment import merge_real_mileage
+    from src.dashboard.data_loader import compute_signals
+
+    listings = get_listings_df(session)
+    if listings is None or listings.empty:
+        logger.info("value_gate: no listings")
+        return []
+    listings = enrich_listings(listings)
+    listings = merge_real_mileage(listings)
+    history = get_price_history_df(session)
+    turnover = compute_turnover_stats(listings)
+
+    try:
+        signals, *_ = compute_signals(listings, history, turnover=turnover)
+    except Exception as e:  # noqa: BLE001 — a missing/stale model must not crash the run
+        logger.warning("value_gate: compute_signals failed (%s) — no candidates", e)
+        return []
+
+    if signals is None or signals.empty:
+        logger.info("value_gate: compute_signals produced no deals")
+        return []
+
+    required = {"olx_id", "price_eur", "undervaluation_pct", "spec_fill"}
+    missing = required - set(signals.columns)
+    if missing:
+        logger.warning("value_gate: signals missing columns %s — cannot rank", missing)
+        return []
+
+    df = signals.copy()
+    df = df[
+        (df["price_eur"] >= gate["min_price_eur"])
+        & (df["spec_fill"] >= gate["min_spec_fill"])
+        & (df["undervaluation_pct"] > gate["min_discount_pct"])
+        & (df["undervaluation_pct"] <= gate["max_discount_pct"])
+    ]
+    if exclude_ids:
+        df = df[~df["olx_id"].astype(str).isin(exclude_ids)]
+    if df.empty:
+        logger.info("value_gate: no candidates after filters")
+        return []
+
+    df = df.sort_values("undervaluation_pct", ascending=False)
+    ids = [str(x) for x in df["olx_id"].head(limit).tolist()]
+    logger.info(
+        "value_gate: %d candidate deals (top discount %.1f%%), selecting %d",
+        len(df), float(df["undervaluation_pct"].iloc[0]), len(ids),
+    )
+    return ids

--- a/src/cli.py
+++ b/src/cli.py
@@ -818,6 +818,136 @@ def enrich(
     log.info("Enriched %d listings (%d failed).", enriched, failed)
 
 
+@app.command("enrich-openrouter")
+def enrich_openrouter(
+    daily_budget: int = typer.Option(
+        None, help="Override daily OpenRouter request budget (free tier ~50/day). "
+                   "Default from config/settings.yaml openrouter.daily_request_budget."),
+    per_run_cap: int = typer.Option(
+        None, help="Override per-run request cap. Default from config."),
+    dry_run: bool = typer.Option(
+        False, help="Rank + select candidates and print them, but make NO API calls "
+                    "and touch neither the DB nor the budget state file."),
+):
+    """Value-gated enrichment of the top deals via a free OpenRouter model.
+
+    The GBM value model needs no LLM to price a listing, so we rank ALL fresh
+    listings by undervaluation FIRST (via the production deal funnel) and send
+    only the top-K most-undervalued, non-cheap-tail deals to a free OpenRouter
+    model for condition NLP. Spend is bounded by a daily + per-run request
+    budget (free tier ≈ 50/day) tracked in a state file. Safe to run on every
+    scheduled scrape: no-ops (exit 0) when OPENROUTER_API_KEY is unset, when
+    the budget is exhausted, or when no fresh model / no candidate deals exist.
+    """
+    from sqlalchemy import func as sa_func
+    from src.models.listing import Listing
+    from src.parser.openrouter_enrichment import (
+        get_openrouter_config, openrouter_available, openrouter_corrections,
+        enrich_from_description as or_enrich, load_budget, save_budget,
+    )
+    from src.analytics.value_gate import rank_deal_olx_ids
+
+    cfg = get_openrouter_config()
+    if daily_budget is not None:
+        cfg["daily_request_budget"] = daily_budget
+    if per_run_cap is not None:
+        cfg["per_run_request_cap"] = per_run_cap
+
+    # --dry-run only ranks + prints candidates: it makes no API calls, so it
+    # needs neither the key nor budget headroom (useful for validating the
+    # gate anywhere, e.g. on the scrape host without the secret exported).
+    if not dry_run and not openrouter_available():
+        log.warning("OPENROUTER_API_KEY not set — skipping OpenRouter enrichment.")
+        return
+
+    budget = load_budget(cfg["budget_state_file"])
+    daily_remaining = max(0, int(cfg["daily_request_budget"]) - budget["requests"])
+    run_request_budget = min(int(cfg["per_run_request_cap"]), daily_remaining)
+    if not dry_run and run_request_budget <= 0:
+        log.info("OpenRouter daily budget exhausted (%d/%d used today) — skipping.",
+                 budget["requests"], cfg["daily_request_budget"])
+        return
+
+    init_db()
+    session = get_session()
+
+    # Exclude listings already OpenRouter-enriched (marker stored in llm_extras).
+    already = {
+        oid for (oid,) in session.query(Listing.olx_id).filter(
+            sa_func.json_extract(Listing.llm_extras, "$._or_enriched").isnot(None)
+        ).all()
+    }
+
+    # Fetch a few more candidates than the request budget — some are skipped
+    # (too-short descriptions cost 0 requests) so we can still fill the budget.
+    # For a dry run the budget may be 0, so fall back to the per-run cap to show
+    # a meaningful candidate list.
+    candidate_limit = (run_request_budget or int(cfg["per_run_request_cap"])) + 5
+    ranked_ids = rank_deal_olx_ids(
+        session, gate=cfg["gate"], limit=candidate_limit, exclude_ids=already,
+    )
+    if not ranked_ids:
+        log.info("OpenRouter gate: no candidate deals to enrich.")
+        return
+
+    if dry_run:
+        log.info("DRY RUN — %d candidate deals (run budget %d req, daily remaining %d):",
+                 len(ranked_ids), run_request_budget, daily_remaining)
+        for oid in ranked_ids:
+            log.info("  candidate olx_id=%s", oid)
+        return
+
+    rows = {
+        l.olx_id: l for l in session.query(Listing).filter(Listing.olx_id.in_(ranked_ids)).all()
+    }
+    log.info("OpenRouter enrichment: up to %d requests this run (daily remaining %d), "
+             "models=%s", run_request_budget, daily_remaining, cfg["models"])
+
+    requests_spent = 0
+    enriched = 0
+    failed = 0
+    consecutive_failures = 0
+    for oid in ranked_ids:
+        if requests_spent >= run_request_budget:
+            break
+        listing = rows.get(oid)
+        if listing is None:
+            continue
+        remaining = run_request_budget - requests_spent
+        result, n_req = or_enrich(
+            listing.description or "", listing.title or "", cfg, request_cap=remaining,
+        )
+        requests_spent += n_req
+        if result:
+            listing._llm_extras = result
+            corrections = openrouter_corrections(listing)
+            if "damage_severity" in corrections:
+                result["damage_severity"] = corrections["damage_severity"]
+            result["_or_enriched"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            listing.llm_extras = json.dumps(result, ensure_ascii=False)
+            for field, value in corrections.items():
+                if hasattr(listing, field):
+                    setattr(listing, field, value)
+            enriched += 1
+            consecutive_failures = 0
+            session.commit()
+            log.info("OpenRouter enriched %s (%d/%d req)", oid, requests_spent, run_request_budget)
+        elif n_req > 0:
+            # A real API attempt that failed (429 chain exhausted / bad output).
+            failed += 1
+            consecutive_failures += 1
+            if consecutive_failures >= 5:
+                log.warning("5 consecutive OpenRouter failures (rate-limited?) — stopping run.")
+                break
+        # n_req == 0 → description too short to enrich; skip silently.
+
+    session.commit()
+    save_budget(cfg["budget_state_file"], budget["requests"] + requests_spent)
+    log.info("OpenRouter enrichment done: %d enriched, %d failed, %d requests "
+             "(daily total %d/%d).", enriched, failed, requests_spent,
+             budget["requests"] + requests_spent, cfg["daily_request_budget"])
+
+
 @app.command("verify-photos")
 def verify_photos(
     threshold: float = typer.Option(0.20, help="P(damaged) threshold (0.20 = production default, F1=0.818 R=100%% on gold)."),

--- a/src/cli.py
+++ b/src/cli.py
@@ -907,42 +907,59 @@ def enrich_openrouter(
     enriched = 0
     failed = 0
     consecutive_failures = 0
-    for oid in ranked_ids:
-        if requests_spent >= run_request_budget:
-            break
-        listing = rows.get(oid)
-        if listing is None:
-            continue
-        remaining = run_request_budget - requests_spent
-        result, n_req = or_enrich(
-            listing.description or "", listing.title or "", cfg, request_cap=remaining,
-        )
-        requests_spent += n_req
-        if result:
-            listing._llm_extras = result
-            corrections = openrouter_corrections(listing)
-            if "damage_severity" in corrections:
-                result["damage_severity"] = corrections["damage_severity"]
-            result["_or_enriched"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-            listing.llm_extras = json.dumps(result, ensure_ascii=False)
-            for field, value in corrections.items():
-                if hasattr(listing, field):
-                    setattr(listing, field, value)
-            enriched += 1
-            consecutive_failures = 0
-            session.commit()
-            log.info("OpenRouter enriched %s (%d/%d req)", oid, requests_spent, run_request_budget)
-        elif n_req > 0:
-            # A real API attempt that failed (429 chain exhausted / bad output).
-            failed += 1
-            consecutive_failures += 1
-            if consecutive_failures >= 5:
-                log.warning("5 consecutive OpenRouter failures (rate-limited?) — stopping run.")
+    try:
+        for oid in ranked_ids:
+            if requests_spent >= run_request_budget:
                 break
-        # n_req == 0 → description too short to enrich; skip silently.
-
-    session.commit()
-    save_budget(cfg["budget_state_file"], budget["requests"] + requests_spent)
+            listing = rows.get(oid)
+            if listing is None:
+                continue
+            remaining = run_request_budget - requests_spent
+            try:
+                result, n_req = or_enrich(
+                    listing.description or "", listing.title or "", cfg, request_cap=remaining,
+                )
+            except Exception as e:  # noqa: BLE001 — one bad listing must not abort the run
+                log.warning("OpenRouter call raised for %s: %s", oid, e)
+                result, n_req = None, 0
+            requests_spent += n_req
+            # Persist the running spend after EVERY call: the workflow step has a
+            # 20-min SIGKILL and the concurrency rule can cancel this late step, so
+            # a single end-of-loop save would silently drop the spend and let the
+            # next of the day's runs re-spend past the free-tier ceiling.
+            save_budget(cfg["budget_state_file"], budget["requests"] + requests_spent)
+            if result:
+                try:
+                    listing._llm_extras = result
+                    corrections = openrouter_corrections(listing)
+                    if "damage_severity" in corrections:
+                        result["damage_severity"] = corrections["damage_severity"]
+                    result["_or_enriched"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                    listing.llm_extras = json.dumps(result, ensure_ascii=False)
+                    for field, value in corrections.items():
+                        if hasattr(listing, field):
+                            setattr(listing, field, value)
+                    session.commit()
+                except Exception as e:  # noqa: BLE001 — DB lock contention etc. must not abort
+                    log.warning("OpenRouter DB write failed for %s: %s — rolling back", oid, e)
+                    session.rollback()
+                    continue
+                enriched += 1
+                consecutive_failures = 0
+                log.info("OpenRouter enriched %s (%d/%d req)", oid, requests_spent, run_request_budget)
+            elif n_req > 0:
+                # A real API attempt that failed (429 chain exhausted / bad output).
+                failed += 1
+                consecutive_failures += 1
+                if consecutive_failures >= 3:
+                    log.warning("3 consecutive OpenRouter failures (free tier rate-limited?) "
+                                "— stopping run to preserve daily budget.")
+                    break
+            # n_req == 0 → description too short (or the call raised); skip silently.
+    finally:
+        # Belt-and-suspenders for the exception path (SIGKILL bypasses finally,
+        # which is why the per-call save above is the real guard).
+        save_budget(cfg["budget_state_file"], budget["requests"] + requests_spent)
     log.info("OpenRouter enrichment done: %d enriched, %d failed, %d requests "
              "(daily total %d/%d).", enriched, failed, requests_spent,
              budget["requests"] + requests_spent, cfg["daily_request_budget"])

--- a/src/parser/openrouter_enrichment.py
+++ b/src/parser/openrouter_enrichment.py
@@ -130,7 +130,12 @@ def get_openrouter_config() -> dict:
         "max_tokens": cfg.get("max_tokens", 500),
         "max_chars": cfg.get("max_chars", 2500),
         "timeout_seconds": cfg.get("timeout_seconds", 90),
-        "max_retries": cfg.get("max_retries", 1),
+        # 0 = no same-model retry: a free-model 429 is upstream congestion that
+        # an immediate retry rarely clears (a stuck model 429s repeatedly — see
+        # the 2026-07-24 shootout), so we advance the fallback chain instead of
+        # burning budget on same-model retries.
+        "max_retries": cfg.get("max_retries", 0),
+        "retry_backoff_seconds": cfg.get("retry_backoff_seconds", 1.0),
         "referer": cfg.get("referer", "https://olx-car-parser.permikov134.workers.dev"),
         "title": cfg.get("title", "olx-car-parser"),
         "daily_request_budget": cfg.get("daily_request_budget", 45),
@@ -196,9 +201,14 @@ def remaining_daily(cfg: dict) -> int:
 # Core API call
 # ---------------------------------------------------------------------------
 
-def _parse_json_object(content: str) -> dict | None:
-    """Parse a chat-completion string into a JSON object, tolerating ```fences```."""
-    if not content:
+def _parse_json_object(content) -> dict | None:
+    """Parse a chat-completion string into a JSON object, tolerating ```fences```.
+
+    Defensive against a provider returning a non-string ``content`` (null, or a
+    structured content array) — anything that isn't a non-empty str yields None
+    rather than an AttributeError that would abort the whole enrichment run.
+    """
+    if not isinstance(content, str) or not content.strip():
         return None
     t = content.strip()
     if t.startswith("```"):
@@ -285,7 +295,10 @@ def call_openrouter(text: str, cfg: dict, *, request_cap: int | None = None) -> 
                     break  # bad output → next model, not a retry
                 if resp.status_code == 429 or resp.status_code >= 500:
                     logger.info("OpenRouter %s HTTP %s (attempt %d)", model, resp.status_code, attempt + 1)
-                    continue  # retry same model, then fall through to next
+                    backoff = float(cfg.get("retry_backoff_seconds", 0) or 0)
+                    if backoff and (attempt < int(cfg.get("max_retries", 0)) or model != cfg["models"][-1]):
+                        time.sleep(backoff)  # brief pause before same-model retry or next model
+                    continue  # retry same model (if retries left), then fall through to next
                 if resp.status_code in (401, 402, 403):
                     # Account-level failure (bad key / no credits / forbidden) —
                     # no other model in the chain will help, so abort the call.

--- a/src/parser/openrouter_enrichment.py
+++ b/src/parser/openrouter_enrichment.py
@@ -286,10 +286,17 @@ def call_openrouter(text: str, cfg: dict, *, request_cap: int | None = None) -> 
                 if resp.status_code == 429 or resp.status_code >= 500:
                     logger.info("OpenRouter %s HTTP %s (attempt %d)", model, resp.status_code, attempt + 1)
                     continue  # retry same model, then fall through to next
-                # 4xx other than 429 (401/402/400) → hard stop, no point retrying
-                logger.warning("OpenRouter %s HTTP %s — aborting: %s",
+                if resp.status_code in (401, 402, 403):
+                    # Account-level failure (bad key / no credits / forbidden) —
+                    # no other model in the chain will help, so abort the call.
+                    logger.warning("OpenRouter account error HTTP %s — aborting: %s",
+                                   resp.status_code, resp.text[:200])
+                    return None, n_requests
+                # Any other 4xx (400 bad request, 404 model delisted, …) is
+                # model-specific — advance to the next model rather than abort.
+                logger.warning("OpenRouter %s HTTP %s — trying next model: %s",
                                model, resp.status_code, resp.text[:200])
-                return None, n_requests
+                break
     return None, n_requests
 
 

--- a/src/parser/openrouter_enrichment.py
+++ b/src/parser/openrouter_enrichment.py
@@ -1,0 +1,341 @@
+"""Value-gated LLM enrichment via OpenRouter (free-tier cloud models).
+
+This is the cloud counterpart to :mod:`src.parser.llm_enrichment` (local
+Ollama). The Ollama inference pool was retired 2026-07-24; scheduled scrape
+runs now go raw-only. To recover *some* LLM signal without a self-hosted GPU,
+we send only the small set of GENUINELY INTERESTING listings — the top deals
+the GBM value model already flags as undervalued (see
+:mod:`src.analytics.value_gate`) — to a free OpenRouter model.
+
+Two reasons the call is gated hard:
+  1. Free-tier OpenRouter caps requests at ~50/day and free models are
+     frequently upstream-rate-limited (HTTP 429). A per-run + daily request
+     budget (state file) keeps us under the ceiling.
+  2. The value-add is on deals: reading a Portuguese description for
+     condition / accident / owner / negotiability closes the "condition-blind"
+     gap in the price model exactly where it matters (the surfaced deals).
+
+Unlike the slim Ollama schema (sub_model / trim_level / mileage only), this
+path also extracts the condition fields the decision engine already consumes:
+mechanical_condition, desc_mentions_accident/repair/num_owners/customs_cleared,
+right_hand_drive, warranty, urgency — plus display-only negotiable / red_flags
+/ deal_note_pt kept in ``llm_extras``. The extracted keys are named to match
+the DB columns so the write path is a plain ``setattr``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+import httpx
+import yaml
+
+# Reuse the validated primitives from the Ollama path — one source of truth
+# for sub_model brand-family validation, mileage sanity bounds, and the
+# deterministic damage_severity derivation.
+from src.parser.llm_enrichment import (
+    _validate_sub_model,
+    _derive_damage_severity,
+    _MILEAGE_SANITY_MAX_KM,
+    _MILEAGE_SANITY_RELATIVE_MAX,
+    correct_listing_data,
+)
+
+logger = logging.getLogger(__name__)
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "settings.yaml"
+
+# Env var holding the OpenRouter API key (never stored in settings.yaml —
+# same convention as TELEGRAM_BOT_TOKEN / CF_DEPLOY_HOOK_URL).
+API_KEY_ENV = "OPENROUTER_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Extraction prompt — base 3 fields + condition NLP
+# ---------------------------------------------------------------------------
+# The JSON keys are the DB column names on purpose (desc_mentions_*, urgency,
+# warranty, mechanical_condition) so persistence is a straight setattr. Enums
+# are English lowercase to match the exact vocab the consumers compare against
+# (data_loader.compute_signals / _blocking_deal_reason, analytics.decision):
+#   urgency ∈ {high, medium, low}; mechanical_condition ∈ {excellent, good,
+#   fair, poor}. desc_mentions_accident / right_hand_drive / damage_severity≥3
+#   are HARD funnel vetoes — the prompt demands they be true ONLY when the text
+#   states it explicitly (high precision, never guessed).
+_SYSTEM_PROMPT = """\
+You extract structured facts from a Portuguese (pt-PT) used-car listing and return ONE JSON object. Use null when a field cannot be determined from the text. Output ONLY the JSON object, no markdown, no commentary.
+
+Return exactly these keys:
+sub_model: engine/body variant only (displacement+fuel+power), e.g. "320d","1.6 TDI","2.0 TFSI","A 200". NOT a trim/package, NOT a bare model name. Tech tags belong to specific brand families — never assign a tag from the wrong family: TDI/TFSI/TSI = VAG only (VW/Audi/Seat/Skoda); HDi/BlueHDi/PureTech = PSA only (Peugeot/Citroën/DS); CDI/BlueTec = Mercedes only; dCi/TCe = Renault/Dacia/Nissan only; M-Jet/Multijet = FCA only (Fiat/Alfa Romeo); TDCi/EcoBoost = Ford only. BMW uses model-code form (116d, 320d, 535d) — never "1.6 TDI", never just "Touring"/"xDrive". If unsure, null.
+trim_level: equipment line e.g. "AMG Line","M Sport","S-Line","GTI","FR","Tekna". null if basic.
+mileage_in_description_km: integer km. "mil"=thousand only as a separate word ("150 mil km"→150000; "89.500km"→89500). Service-interval km ("revisão aos 60.000 km") is NOT current mileage.
+mechanical_condition: one of "excellent","good","fair","poor" — overall mechanical state as described. null if not indicated.
+desc_mentions_accident: true ONLY if the text explicitly states the car had an accident / crash / "sinistrado" / "batido" / "acidente". Otherwise false. (This removes the car from deals — be strict.)
+desc_mentions_repair: true if the text says it needs repair / has a known mechanical fault / "para arranjar" / "avaria". Otherwise false.
+desc_mentions_num_owners: integer number of owners if stated ("2 donos"→2, "único dono"/"1 dono"→1). null if not stated.
+desc_mentions_customs_cleared: true if it explicitly mentions being imported AND customs-cleared / "legalizado" / "nacionalizado" / "ISV pago". Otherwise false.
+right_hand_drive: true ONLY if explicitly right-hand drive / "volante à direita" / UK import RHD. Otherwise false. (This removes the car from deals — be strict.)
+warranty: true if the seller offers a warranty / "garantia" (not "sem garantia"). Otherwise false.
+urgency: "high" if the seller signals urgency / quick sale / "venda urgente" / "preço negociável para venda rápida"; "medium" if mildly motivated; "low" otherwise.
+negotiable: true if price is negotiable / "negociável" / "aceito retoma". Otherwise false.
+red_flags: array of short pt-PT strings naming concrete concerns (high km, damage, many owners, import doubts). Empty array if none.
+deal_note_pt: one short pt-PT phrase (≤120 chars) summarising the listing as a deal. null if nothing notable.
+
+Example:
+"BMW Série 3 320d Pack M, 180.000 km, 1 dono, garantia até 2026, nunca sinistrado, negociável."
+→ {"sub_model":"320d","trim_level":"Pack M","mileage_in_description_km":180000,"mechanical_condition":"good","desc_mentions_accident":false,"desc_mentions_repair":false,"desc_mentions_num_owners":1,"desc_mentions_customs_cleared":false,"right_hand_drive":false,"warranty":true,"urgency":"low","negotiable":true,"red_flags":["quilometragem elevada"],"deal_note_pt":"320d Pack M com 1 dono e garantia, preço negociável"}
+"""
+
+
+# Which extracted keys map to real DB columns (written via setattr), with the
+# type each column expects. Keys NOT here (negotiable, red_flags, deal_note_pt)
+# live only in llm_extras JSON. sub_model / trim_level / real_mileage_km /
+# damage_severity come from correct_listing_data (reused), so they are excluded
+# here to avoid double-writing.
+_BOOL_COLUMNS = (
+    "desc_mentions_accident",
+    "desc_mentions_repair",
+    "desc_mentions_customs_cleared",
+    "right_hand_drive",
+    "warranty",
+)
+_STR_ENUM_COLUMNS = {
+    "mechanical_condition": {"excellent", "good", "fair", "poor"},
+    "urgency": {"high", "medium", "low"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def get_openrouter_config() -> dict:
+    """Load the ``openrouter`` section of settings.yaml with safe defaults."""
+    cfg = {}
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            data = yaml.safe_load(f) or {}
+        cfg = data.get("openrouter", {}) or {}
+    gate = cfg.get("gate", {}) or {}
+    return {
+        "base_url": cfg.get("base_url", "https://openrouter.ai/api/v1"),
+        "models": cfg.get("models") or [
+            "google/gemma-4-26b-a4b-it:free",
+            "google/gemma-4-31b-it:free",
+            "openai/gpt-oss-20b:free",
+        ],
+        "temperature": cfg.get("temperature", 0.1),
+        "max_tokens": cfg.get("max_tokens", 500),
+        "max_chars": cfg.get("max_chars", 2500),
+        "timeout_seconds": cfg.get("timeout_seconds", 90),
+        "max_retries": cfg.get("max_retries", 1),
+        "referer": cfg.get("referer", "https://olx-car-parser.permikov134.workers.dev"),
+        "title": cfg.get("title", "olx-car-parser"),
+        "daily_request_budget": cfg.get("daily_request_budget", 45),
+        "per_run_request_cap": cfg.get("per_run_request_cap", 15),
+        "budget_state_file": cfg.get("budget_state_file", "data/openrouter_budget.json"),
+        "gate": {
+            "min_price_eur": gate.get("min_price_eur", 4000),
+            "min_spec_fill": gate.get("min_spec_fill", 0.5),
+            "max_band_pct": gate.get("max_band_pct", 0.40),
+            "min_discount_pct": gate.get("min_discount_pct", 0.0),
+            "max_discount_pct": gate.get("max_discount_pct", 60.0),
+        },
+    }
+
+
+def get_api_key() -> str | None:
+    key = os.environ.get(API_KEY_ENV, "").strip()
+    return key or None
+
+
+def openrouter_available() -> bool:
+    return get_api_key() is not None
+
+
+# ---------------------------------------------------------------------------
+# Daily / per-run request budget (free-tier ~50/day ceiling)
+# ---------------------------------------------------------------------------
+
+def _today() -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime())
+
+
+def load_budget(state_path: str | Path) -> dict:
+    """Return {'date': 'YYYY-MM-DD', 'requests': int} for *today*.
+
+    Resets to zero when the stored date is not today (UTC), so the free-tier
+    daily allowance rolls over automatically.
+    """
+    path = Path(state_path)
+    today = _today()
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            if data.get("date") == today:
+                return {"date": today, "requests": int(data.get("requests", 0))}
+        except (json.JSONDecodeError, ValueError, OSError):
+            pass
+    return {"date": today, "requests": 0}
+
+
+def save_budget(state_path: str | Path, requests_spent: int) -> None:
+    path = Path(state_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"date": _today(), "requests": int(requests_spent)}))
+
+
+def remaining_daily(cfg: dict) -> int:
+    b = load_budget(cfg["budget_state_file"])
+    return max(0, int(cfg["daily_request_budget"]) - b["requests"])
+
+
+# ---------------------------------------------------------------------------
+# Core API call
+# ---------------------------------------------------------------------------
+
+def _parse_json_object(content: str) -> dict | None:
+    """Parse a chat-completion string into a JSON object, tolerating ```fences```."""
+    if not content:
+        return None
+    t = content.strip()
+    if t.startswith("```"):
+        t = t.lstrip("`")
+        if t[:4].lower() == "json":
+            t = t[4:]
+        t = t.strip().rstrip("`").strip()
+    try:
+        parsed = json.loads(t)
+    except json.JSONDecodeError:
+        # Last resort: slice the outermost {...}.
+        start, end = t.find("{"), t.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                parsed = json.loads(t[start:end + 1])
+            except json.JSONDecodeError:
+                return None
+        else:
+            return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def call_openrouter(text: str, cfg: dict, *, request_cap: int | None = None) -> tuple[dict | None, int]:
+    """Run one extraction against the OpenRouter free-model fallback chain.
+
+    Tries each model in ``cfg['models']`` in order; on HTTP 429 (free model
+    upstream-rate-limited) or 5xx it advances to the next model, retrying each
+    up to ``cfg['max_retries']`` times. Returns ``(extras_dict_or_None,
+    n_requests_made)`` — the caller uses ``n_requests_made`` for budget
+    accounting (each HTTP POST counts against the free-tier daily allowance).
+
+    ``request_cap`` hard-limits how many HTTP requests this single call may
+    make (so one wedged listing can't drain the whole per-run budget).
+    """
+    key = get_api_key()
+    if not key:
+        return None, 0
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": cfg["referer"],
+        "X-Title": cfg["title"],
+    }
+    truncated = text[: cfg.get("max_chars", 2500)]
+    body_base = {
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": truncated},
+        ],
+        "temperature": cfg.get("temperature", 0.1),
+        "max_tokens": cfg.get("max_tokens", 500),
+        "response_format": {"type": "json_object"},
+    }
+    url = cfg["base_url"].rstrip("/") + "/chat/completions"
+    n_requests = 0
+    with httpx.Client(timeout=httpx.Timeout(float(cfg.get("timeout_seconds", 90)), connect=10.0)) as client:
+        for model in cfg["models"]:
+            for attempt in range(int(cfg.get("max_retries", 1)) + 1):
+                if request_cap is not None and n_requests >= request_cap:
+                    return None, n_requests
+                body = dict(body_base, model=model)
+                # gemma free rejects response_format upstream on some providers;
+                # drop it for gemma and rely on the prompt's "ONLY JSON".
+                if "gemma" in model:
+                    body.pop("response_format", None)
+                try:
+                    resp = client.post(url, json=body, headers=headers)
+                    n_requests += 1
+                except httpx.RequestError as e:
+                    logger.warning("OpenRouter connection error (%s): %s", model, e)
+                    n_requests += 1
+                    break  # try next model
+                if resp.status_code == 200:
+                    try:
+                        j = resp.json()
+                        content = j["choices"][0]["message"]["content"]
+                    except (KeyError, IndexError, json.JSONDecodeError, ValueError):
+                        logger.warning("OpenRouter malformed 200 body (%s)", model)
+                        break
+                    parsed = _parse_json_object(content)
+                    if parsed is not None:
+                        return parsed, n_requests
+                    logger.info("OpenRouter %s returned non-JSON; trying next model", model)
+                    break  # bad output → next model, not a retry
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    logger.info("OpenRouter %s HTTP %s (attempt %d)", model, resp.status_code, attempt + 1)
+                    continue  # retry same model, then fall through to next
+                # 4xx other than 429 (401/402/400) → hard stop, no point retrying
+                logger.warning("OpenRouter %s HTTP %s — aborting: %s",
+                               model, resp.status_code, resp.text[:200])
+                return None, n_requests
+    return None, n_requests
+
+
+# ---------------------------------------------------------------------------
+# Corrections — base fields (reused) + condition columns
+# ---------------------------------------------------------------------------
+
+def openrouter_corrections(listing) -> dict:
+    """Corrections dict for a listing whose ``_llm_extras`` came from OpenRouter.
+
+    Combines the reused base corrections (sub_model / trim_level /
+    real_mileage_km / damage_severity, via :func:`correct_listing_data`) with
+    the condition columns unique to this richer schema. All keys are real
+    Listing columns, so the caller writes them with ``setattr`` (same seam as
+    the ``enrich`` command).
+    """
+    extras = getattr(listing, "_llm_extras", None)
+    if not isinstance(extras, dict):
+        return {}
+
+    corrections = correct_listing_data(listing)  # sub_model/trim/mileage/damage_severity
+
+    for col in _BOOL_COLUMNS:
+        if col in extras and isinstance(extras[col], bool):
+            corrections[col] = extras[col]
+
+    n_owners = extras.get("desc_mentions_num_owners")
+    if isinstance(n_owners, (int, float)) and not isinstance(n_owners, bool) and n_owners > 0:
+        corrections["desc_mentions_num_owners"] = int(n_owners)
+
+    for col, allowed in _STR_ENUM_COLUMNS.items():
+        val = extras.get(col)
+        if isinstance(val, str) and val.strip().lower() in allowed:
+            corrections[col] = val.strip().lower()
+
+    return corrections
+
+
+def enrich_from_description(description: str, title: str, cfg: dict,
+                           *, request_cap: int | None = None) -> tuple[dict | None, int]:
+    """Extract structured data from title+description via OpenRouter.
+
+    Returns ``(extras_or_None, n_requests_made)``. Mirrors the local-path
+    ``enrich_from_description`` contract but with request accounting.
+    """
+    if not description or len(description.strip()) < 20:
+        return None, 0
+    text = f"{title}\n{description}" if title else description
+    return call_openrouter(text, cfg, request_cap=request_cap)

--- a/tests/test_openrouter_enrichment.py
+++ b/tests/test_openrouter_enrichment.py
@@ -144,7 +144,7 @@ def _cfg():
         "base_url": "https://openrouter.ai/api/v1",
         "models": ["google/gemma-4-26b-a4b-it:free", "google/gemma-4-31b-it:free"],
         "temperature": 0.1, "max_tokens": 500, "max_chars": 2500,
-        "timeout_seconds": 90, "max_retries": 1,
+        "timeout_seconds": 90, "max_retries": 1, "retry_backoff_seconds": 0,
         "referer": "r", "title": "t",
     }
 
@@ -229,6 +229,153 @@ def test_call_openrouter_respects_request_cap(monkeypatch, _cfg):
 def test_enrich_from_description_short_desc_zero_requests(_cfg):
     out, n = ore.enrich_from_description("short", "", _cfg)
     assert out is None and n == 0
+
+
+def test_call_openrouter_malformed_200_falls_through(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    # model1: 200 but body has no 'choices'; model2: valid
+    fake = _FakeClient([_Resp(200, {"unexpected": 1}), _Resp(200, _content({"warranty": True}))])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg)
+    assert out == {"warranty": True}
+    assert n == 2
+
+
+def test_call_openrouter_non_json_content_falls_through(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    fake = _FakeClient([
+        _Resp(200, {"choices": [{"message": {"content": "sorry, I cannot help"}}]}),
+        _Resp(200, _content({"urgency": "low"})),
+    ])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg)
+    assert out == {"urgency": "low"}
+    assert n == 2
+
+
+def test_call_openrouter_response_format_dropped_only_for_gemma(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    cfg = {
+        "base_url": "https://openrouter.ai/api/v1",
+        "models": ["google/gemma-4-26b-a4b-it:free", "openai/gpt-oss-20b:free"],
+        "temperature": 0.1, "max_tokens": 500, "max_chars": 2500,
+        "timeout_seconds": 90, "max_retries": 0, "retry_backoff_seconds": 0,
+        "referer": "r", "title": "t",
+    }
+    # gemma (model1) 404 → advance; gpt-oss (model2) succeeds
+    fake = _FakeClient([_Resp(404, text="x"), _Resp(200, _content({"sub_model": "A 200"}))])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", cfg)
+    assert out == {"sub_model": "A 200"}
+    assert "response_format" not in fake.calls[0]      # gemma body: dropped
+    assert fake.calls[1]["response_format"] == {"type": "json_object"}  # non-gemma: kept
+
+
+# ---------------------------------------------------------------------------
+# Value gate — failure-mode robustness
+# ---------------------------------------------------------------------------
+
+def _patch_gate_loaders(monkeypatch, compute_signals_impl):
+    monkeypatch.setattr("src.storage.repository.get_listings_df", lambda s: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr("src.storage.repository.get_price_history_df", lambda s: pd.DataFrame())
+    monkeypatch.setattr("src.analytics.computed_columns.enrich_listings", lambda df: df)
+    monkeypatch.setattr("src.analytics.turnover.compute_turnover_stats", lambda df: pd.DataFrame())
+    monkeypatch.setattr("src.parser.llm_enrichment.merge_real_mileage", lambda df: df)
+    monkeypatch.setattr("src.dashboard.data_loader.compute_signals", compute_signals_impl)
+
+
+_GATE = {"min_price_eur": 4000, "min_spec_fill": 0.5, "max_band_pct": 0.40,
+         "min_discount_pct": 0.0, "max_discount_pct": 60.0}
+
+
+def test_rank_deal_olx_ids_compute_signals_raises(monkeypatch):
+    from src.analytics import value_gate
+
+    def boom(l, h, turnover=None):
+        raise RuntimeError("no fresh model")
+    _patch_gate_loaders(monkeypatch, boom)
+    assert value_gate.rank_deal_olx_ids(None, gate=_GATE, limit=5) == []
+
+
+def test_rank_deal_olx_ids_missing_column(monkeypatch):
+    from src.analytics import value_gate
+    # signals lacking 'spec_fill' → gate cannot rank → []
+    sig = pd.DataFrame([{"olx_id": "A", "price_eur": 9000, "undervaluation_pct": 30.0}])
+    _patch_gate_loaders(monkeypatch, lambda l, h, turnover=None: (sig, None, None, None, None, None))
+    assert value_gate.rank_deal_olx_ids(None, gate=_GATE, limit=5) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end — budget accrual + exclude-marker across two runs
+# ---------------------------------------------------------------------------
+
+def test_enrich_openrouter_cli_e2e(tmp_path, monkeypatch):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from typer.testing import CliRunner
+    from src.cli import app
+    from src.models.listing import Listing
+
+    db = tmp_path / "t.db"
+    engine = create_engine(f"sqlite:///{db}")
+    Listing.metadata.create_all(engine)
+    TS = sessionmaker(bind=engine)
+    seed = TS()
+    seed.add_all([
+        Listing(olx_id="A", url="http://a", brand="BMW", model="Serie 3",
+                title="BMW 320d", description="BMW 320d 2015 nacional impecavel, 2 donos, negociavel"),
+        Listing(olx_id="B", url="http://b", brand="Audi", model="A4",
+                title="Audi A4", description="Audi A4 2.0 TDI 2016 nacional, garantia, sem acidentes"),
+    ])
+    seed.commit()
+    seed.close()
+
+    budget_file = tmp_path / "budget.json"
+    cfg = {
+        "base_url": "https://openrouter.ai/api/v1",
+        "models": ["google/gemma-4-26b-a4b-it:free"],
+        "temperature": 0.1, "max_tokens": 500, "max_chars": 2500,
+        "timeout_seconds": 90, "max_retries": 0, "retry_backoff_seconds": 0,
+        "referer": "r", "title": "t",
+        "daily_request_budget": 10, "per_run_request_cap": 5,
+        "budget_state_file": str(budget_file), "gate": {},
+    }
+
+    all_ids = ["A", "B"]
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setattr("src.cli.init_db", lambda *a, **k: None)
+    monkeypatch.setattr("src.cli.get_session", lambda: TS())
+    monkeypatch.setattr("src.parser.openrouter_enrichment.get_openrouter_config", lambda: dict(cfg))
+    monkeypatch.setattr(
+        "src.analytics.value_gate.rank_deal_olx_ids",
+        lambda session, *, gate, limit, exclude_ids=frozenset():
+            [i for i in all_ids if i not in exclude_ids][:limit],
+    )
+    monkeypatch.setattr(
+        "src.parser.openrouter_enrichment.call_openrouter",
+        lambda text, cfg, request_cap=None: (
+            {"mechanical_condition": "good", "desc_mentions_accident": False,
+             "warranty": True, "urgency": "low"}, 1),
+    )
+
+    runner = CliRunner()
+    r1 = runner.invoke(app, ["enrich-openrouter"])
+    assert r1.exit_code == 0, r1.output
+
+    # both listings enriched; budget = 2 requests
+    assert json.loads(budget_file.read_text())["requests"] == 2
+    chk = TS()
+    rows = {l.olx_id: l for l in chk.query(Listing).all()}
+    assert rows["A"].mechanical_condition == "good"
+    assert rows["A"].warranty is True
+    assert "_or_enriched" in json.loads(rows["A"].llm_extras)
+    chk.close()
+
+    # second run: both already marked → excluded → no new spend
+    r2 = runner.invoke(app, ["enrich-openrouter"])
+    assert r2.exit_code == 0, r2.output
+    assert json.loads(budget_file.read_text())["requests"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_openrouter_enrichment.py
+++ b/tests/test_openrouter_enrichment.py
@@ -1,0 +1,296 @@
+"""Tests for the value-gated OpenRouter enrichment path."""
+import json
+import types
+
+import pandas as pd
+import pytest
+
+from src.parser import openrouter_enrichment as ore
+
+
+# ---------------------------------------------------------------------------
+# JSON parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_json_object_plain():
+    assert ore._parse_json_object('{"a": 1}') == {"a": 1}
+
+
+def test_parse_json_object_fenced():
+    assert ore._parse_json_object('```json\n{"a": 1}\n```') == {"a": 1}
+    assert ore._parse_json_object('```\n{"a": 2}\n```') == {"a": 2}
+
+
+def test_parse_json_object_with_prose_around():
+    assert ore._parse_json_object('Here you go: {"a": 1, "b": true} done') == {"a": 1, "b": True}
+
+
+def test_parse_json_object_garbage():
+    assert ore._parse_json_object("not json at all") is None
+    assert ore._parse_json_object("") is None
+    assert ore._parse_json_object("[1,2,3]") is None  # array is not an object
+
+
+# ---------------------------------------------------------------------------
+# Corrections — vocab validation + column mapping
+# ---------------------------------------------------------------------------
+
+class _Listing:
+    def __init__(self, extras, brand="BMW", mileage_km=180000, title="", description=""):
+        self._llm_extras = extras
+        self.brand = brand
+        self.mileage_km = mileage_km
+        self.title = title
+        self.description = description
+        self.url = "http://x"
+        self.olx_id = "ABC"
+
+
+def test_openrouter_corrections_full_valid():
+    extras = {
+        "sub_model": "320d", "trim_level": "M Sport",
+        "mileage_in_description_km": 180000,
+        "mechanical_condition": "good",
+        "desc_mentions_accident": False, "desc_mentions_repair": True,
+        "desc_mentions_num_owners": 2, "desc_mentions_customs_cleared": False,
+        "right_hand_drive": False, "warranty": True, "urgency": "high",
+        "negotiable": True, "red_flags": ["km alta"], "deal_note_pt": "bom",
+    }
+    c = ore.openrouter_corrections(_Listing(extras))
+    assert c["sub_model"] == "320d"
+    assert c["trim_level"] == "M Sport"
+    assert c["mechanical_condition"] == "good"
+    assert c["desc_mentions_repair"] is True
+    assert c["desc_mentions_accident"] is False
+    assert c["desc_mentions_num_owners"] == 2
+    assert c["warranty"] is True
+    assert c["urgency"] == "high"
+    # damage_severity is derived by correct_listing_data (repair → 2)
+    assert c["damage_severity"] == 2
+    # display-only keys never become corrections/columns
+    assert "negotiable" not in c
+    assert "red_flags" not in c
+    assert "deal_note_pt" not in c
+
+
+def test_openrouter_corrections_rejects_bad_enum():
+    extras = {"mechanical_condition": "razoavel", "urgency": "baixa"}  # PT, not the English vocab
+    c = ore.openrouter_corrections(_Listing(extras))
+    assert "mechanical_condition" not in c
+    assert "urgency" not in c
+
+
+def test_openrouter_corrections_enum_case_normalized():
+    c = ore.openrouter_corrections(_Listing({"urgency": "HIGH", "mechanical_condition": "Excellent"}))
+    assert c["urgency"] == "high"
+    assert c["mechanical_condition"] == "excellent"
+
+
+def test_openrouter_corrections_bool_type_strict():
+    # a truthy non-bool must NOT be written to a bool column
+    c = ore.openrouter_corrections(_Listing({"warranty": "yes", "desc_mentions_accident": 1}))
+    assert "warranty" not in c
+    assert "desc_mentions_accident" not in c
+
+
+def test_openrouter_corrections_num_owners_rejects_bool():
+    c = ore.openrouter_corrections(_Listing({"desc_mentions_num_owners": True}))
+    assert "desc_mentions_num_owners" not in c
+
+
+def test_openrouter_corrections_empty_extras():
+    assert ore.openrouter_corrections(_Listing(None)) == {}
+    assert ore.openrouter_corrections(_Listing("not a dict")) == {}
+
+
+# ---------------------------------------------------------------------------
+# call_openrouter — model fallback chain + request accounting
+# ---------------------------------------------------------------------------
+
+class _Resp:
+    def __init__(self, status, payload=None, text=""):
+        self.status_code = status
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    """Minimal httpx.Client stand-in returning scripted responses."""
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        self.calls.append(json)
+        return self._responses.pop(0)
+
+
+def _content(obj):
+    return {"choices": [{"message": {"content": json.dumps(obj)}}]}
+
+
+@pytest.fixture
+def _cfg():
+    return {
+        "base_url": "https://openrouter.ai/api/v1",
+        "models": ["google/gemma-4-26b-a4b-it:free", "google/gemma-4-31b-it:free"],
+        "temperature": 0.1, "max_tokens": 500, "max_chars": 2500,
+        "timeout_seconds": 90, "max_retries": 1,
+        "referer": "r", "title": "t",
+    }
+
+
+def test_call_openrouter_success_first_model(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    fake = _FakeClient([_Resp(200, _content({"sub_model": "320d"}))])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("BMW 320d 180000km nacional impecável", _cfg)
+    assert out == {"sub_model": "320d"}
+    assert n == 1
+
+
+def test_call_openrouter_429_falls_through_to_next_model(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    # model1: 429 twice (initial + 1 retry), model2: 200
+    fake = _FakeClient([
+        _Resp(429, text="rate limited"),
+        _Resp(429, text="rate limited"),
+        _Resp(200, _content({"urgency": "low"})),
+    ])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg)
+    assert out == {"urgency": "low"}
+    assert n == 3
+
+
+def test_call_openrouter_all_fail(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    fake = _FakeClient([_Resp(429), _Resp(429), _Resp(429), _Resp(429)])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg)
+    assert out is None
+    assert n == 4
+
+
+def test_call_openrouter_401_aborts_immediately(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-bad")
+    fake = _FakeClient([_Resp(401, text="unauthorized")])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg)
+    assert out is None
+    assert n == 1  # no fallback attempts on a hard 4xx
+
+
+def test_call_openrouter_no_key(monkeypatch, _cfg):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    out, n = ore.call_openrouter("text", _cfg)
+    assert out is None and n == 0
+
+
+def test_call_openrouter_respects_request_cap(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    fake = _FakeClient([_Resp(429), _Resp(429), _Resp(429), _Resp(429)])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg, request_cap=2)
+    assert out is None
+    assert n == 2
+
+
+def test_enrich_from_description_short_desc_zero_requests(_cfg):
+    out, n = ore.enrich_from_description("short", "", _cfg)
+    assert out is None and n == 0
+
+
+# ---------------------------------------------------------------------------
+# Budget state file
+# ---------------------------------------------------------------------------
+
+def test_budget_roundtrip_and_reset(tmp_path, monkeypatch):
+    state = tmp_path / "budget.json"
+    ore.save_budget(state, 7)
+    assert ore.load_budget(state)["requests"] == 7
+    # stale date → reset to 0
+    state.write_text(json.dumps({"date": "2000-01-01", "requests": 99}))
+    assert ore.load_budget(state)["requests"] == 0
+
+
+def test_remaining_daily(tmp_path):
+    state = tmp_path / "b.json"
+    ore.save_budget(state, 30)
+    cfg = {"budget_state_file": str(state), "daily_request_budget": 40}
+    assert ore.remaining_daily(cfg) == 10
+
+
+# ---------------------------------------------------------------------------
+# Value gate — filter + rank + exclude + limit
+# ---------------------------------------------------------------------------
+
+def test_rank_deal_olx_ids(monkeypatch):
+    from src.analytics import value_gate
+
+    signals = pd.DataFrame([
+        {"olx_id": "keep_top", "price_eur": 12000, "undervaluation_pct": 30.0, "spec_fill": 1.0},
+        {"olx_id": "keep_mid", "price_eur": 9000, "undervaluation_pct": 20.0, "spec_fill": 0.75},
+        {"olx_id": "cheap_tail", "price_eur": 3000, "undervaluation_pct": 50.0, "spec_fill": 1.0},   # < €4k
+        {"olx_id": "low_spec", "price_eur": 8000, "undervaluation_pct": 40.0, "spec_fill": 0.25},    # spec<0.5
+        {"olx_id": "already", "price_eur": 15000, "undervaluation_pct": 35.0, "spec_fill": 1.0},     # excluded
+        {"olx_id": "not_under", "price_eur": 8000, "undervaluation_pct": 0.0, "spec_fill": 1.0},     # disc<=0
+    ])
+
+    def fake_compute_signals(listings, history, turnover=None):
+        return signals, None, None, None, None, None
+
+    monkeypatch.setattr("src.storage.repository.get_listings_df", lambda s: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr("src.storage.repository.get_price_history_df", lambda s: pd.DataFrame())
+    monkeypatch.setattr("src.analytics.computed_columns.enrich_listings", lambda df: df)
+    monkeypatch.setattr("src.analytics.turnover.compute_turnover_stats", lambda df: pd.DataFrame())
+    monkeypatch.setattr("src.parser.llm_enrichment.merge_real_mileage", lambda df: df)
+    monkeypatch.setattr("src.dashboard.data_loader.compute_signals", fake_compute_signals)
+
+    gate = {"min_price_eur": 4000, "min_spec_fill": 0.5, "max_band_pct": 0.40,
+            "min_discount_pct": 0.0, "max_discount_pct": 60.0}
+    ids = value_gate.rank_deal_olx_ids(None, gate=gate, limit=10, exclude_ids={"already"})
+    # cheap_tail, low_spec, already, not_under all filtered → ranked by discount desc
+    assert ids == ["keep_top", "keep_mid"]
+
+
+def test_rank_deal_olx_ids_respects_limit(monkeypatch):
+    from src.analytics import value_gate
+    signals = pd.DataFrame([
+        {"olx_id": f"d{i}", "price_eur": 10000, "undervaluation_pct": float(50 - i), "spec_fill": 1.0}
+        for i in range(10)
+    ])
+    monkeypatch.setattr("src.storage.repository.get_listings_df", lambda s: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr("src.storage.repository.get_price_history_df", lambda s: pd.DataFrame())
+    monkeypatch.setattr("src.analytics.computed_columns.enrich_listings", lambda df: df)
+    monkeypatch.setattr("src.analytics.turnover.compute_turnover_stats", lambda df: pd.DataFrame())
+    monkeypatch.setattr("src.parser.llm_enrichment.merge_real_mileage", lambda df: df)
+    monkeypatch.setattr("src.dashboard.data_loader.compute_signals",
+                        lambda l, h, turnover=None: (signals, None, None, None, None, None))
+    gate = {"min_price_eur": 4000, "min_spec_fill": 0.5, "max_band_pct": 0.40,
+            "min_discount_pct": 0.0, "max_discount_pct": 60.0}
+    ids = value_gate.rank_deal_olx_ids(None, gate=gate, limit=3)
+    assert ids == ["d0", "d1", "d2"]
+
+
+def test_rank_deal_olx_ids_empty_signals(monkeypatch):
+    from src.analytics import value_gate
+    monkeypatch.setattr("src.storage.repository.get_listings_df", lambda s: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr("src.storage.repository.get_price_history_df", lambda s: pd.DataFrame())
+    monkeypatch.setattr("src.analytics.computed_columns.enrich_listings", lambda df: df)
+    monkeypatch.setattr("src.analytics.turnover.compute_turnover_stats", lambda df: pd.DataFrame())
+    monkeypatch.setattr("src.parser.llm_enrichment.merge_real_mileage", lambda df: df)
+    monkeypatch.setattr("src.dashboard.data_loader.compute_signals",
+                        lambda l, h, turnover=None: (pd.DataFrame(), None, None, None, None, None))
+    gate = {"min_price_eur": 4000, "min_spec_fill": 0.5, "max_band_pct": 0.40,
+            "min_discount_pct": 0.0, "max_discount_pct": 60.0}
+    assert value_gate.rank_deal_olx_ids(None, gate=gate, limit=5) == []

--- a/tests/test_openrouter_enrichment.py
+++ b/tests/test_openrouter_enrichment.py
@@ -190,6 +190,27 @@ def test_call_openrouter_401_aborts_immediately(monkeypatch, _cfg):
     assert n == 1  # no fallback attempts on a hard 4xx
 
 
+def test_call_openrouter_404_advances_to_next_model(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    # model1 delisted (404) → should try model2, which succeeds
+    fake = _FakeClient([
+        _Resp(404, text="No endpoints found"),
+        _Resp(200, _content({"sub_model": "1.6 TDI"})),
+    ])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg)
+    assert out == {"sub_model": "1.6 TDI"}
+    assert n == 2
+
+
+def test_call_openrouter_402_no_credits_aborts(monkeypatch, _cfg):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    fake = _FakeClient([_Resp(402, text="insufficient credits")])
+    monkeypatch.setattr(ore.httpx, "Client", lambda **kw: fake)
+    out, n = ore.call_openrouter("some long enough description text here", _cfg)
+    assert out is None and n == 1  # account-level → no fallback
+
+
 def test_call_openrouter_no_key(monkeypatch, _cfg):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     out, n = ore.call_openrouter("text", _cfg)


### PR DESCRIPTION
## What

Recovers LLM enrichment — lost when the Ollama pool was retired (2026-07-24) — for the listings that actually matter: the genuinely-undervalued **deals**. Sends only the top-K most-undervalued listings each day to a **free** OpenRouter model, gated hard so it fits the free tier (~50 requests/day) and never wastes a call on junk.

## How

**Pre-LLM value gate** (`src/analytics/value_gate.py`) — the GBM price model needs no LLM to estimate fair value, so we rank all fresh listings by GBM undervaluation via the production `compute_signals` deal funnel and take only the top-K. Filters: `price ≥ €4k` (skip the condition-blind cheap tail), `spec_fill ≥ 0.5`, plus the band/discount/net gates `compute_signals` already applies. Excludes already-enriched rows.

**OpenRouter client** (`src/parser/openrouter_enrichment.py`) — free-model fallback chain `gemma-4-26b-a4b:free → gemma-4-31b:free → gpt-oss-20b:free`, advances the chain on the frequent upstream 429s (+ model-specific 404/400), aborts only on account errors (401/402/403). Reuses the Ollama path's `sub_model` validation, mileage sanity, and `damage_severity` derivation. **Richer schema** than the slim Ollama one: base 3 fields **plus condition NLP** written to the columns `decide()`/`compute_signals` already consume — `mechanical_condition`, `desc_mentions_accident/repair/num_owners/customs_cleared`, `right_hand_drive`, `warranty`, `urgency` (exact English vocab) — with `negotiable`/`red_flags`/`deal_note_pt` kept in `llm_extras`.

**Request budget** (`data/openrouter_budget.json`, gitignored, persists on the symlinked `data/`) — per-UTC-day + per-run request caps, saved after **every** call (crash-safe against the 20-min step SIGKILL), auto-resets daily.

**CLI** `enrich-openrouter` (`--dry-run` / `--daily-budget` / `--per-run-cap`) — no-ops (exit 0) when `OPENROUTER_API_KEY` unset, budget spent, or no candidates.

**Workflow** — new step after bundle-verify, before build-dashboard/hot_deals, so enriched condition fields propagate into signals + decisions **with no retrain**. Gated on `WITH_OPENROUTER` (default true on schedule, independent of the retired-Ollama `WITH_LLM`) + `train_rc==0` + secret presence; failures non-fatal.

## Validation

- **30 unit tests** (parser / vocab / budget / fallback-chain / value-gate / CLI end-to-end), all green; 661 suite collects clean, no regressions.
- **Host dry-run against the live DB + fresh model**: 15,908 active → 245 signals → **234 candidate deals** (top discount 53.8%), selected the top-K — zero writes/API calls.
- **Adversarial multi-agent review** (10 confirmed findings) applied: budget crash-safety, per-listing error isolation, non-string-content guard, 429 economics.

## Ops

- Key is in the `OPENROUTER_API_KEY` repo secret (already set), never in git.
- Free-tier only. Default budget 40 req/day, 12/run. Merging to `master` is what activates it on the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)